### PR TITLE
Fix incorrect variable name on boolean expression

### DIFF
--- a/packages/project-editor/lvgl/widgets.tsx
+++ b/packages/project-editor/lvgl/widgets.tsx
@@ -1730,7 +1730,7 @@ export class LVGLWidget extends Widget {
                 );
             } else {
                 build.line(
-                    `bool cur_val = ${build.getVariableGetterFunctionName(
+                    `bool new_val = ${build.getVariableGetterFunctionName(
                         this.hiddenFlag as string
                     )}();`
                 );
@@ -1775,7 +1775,7 @@ export class LVGLWidget extends Widget {
                 );
             } else {
                 build.line(
-                    `bool cur_val = ${build.getVariableGetterFunctionName(
+                    `bool new_val = ${build.getVariableGetterFunctionName(
                         this.clickableFlag as string
                     )}();`
                 );


### PR DESCRIPTION
Fixes #354 

Before:

<img width="575" alt="Screenshot 2024-05-05 at 17 13 20" src="https://github.com/eez-open/studio/assets/35956374/0a723595-e8d3-40ec-bb65-73de345d2875">


After:

<img width="613" alt="Screenshot 2024-05-05 at 17 15 38" src="https://github.com/eez-open/studio/assets/35956374/be32d28b-a02a-4bf1-9878-cc9918057aab">
