### PR TITLE
Add flag variable and state variable support for [create_screen_...] functions

### DIFF
--- a/packages/project-editor/lvgl/widgets/Base.tsx
+++ b/packages/project-editor/lvgl/widgets/Base.tsx
@@ -1989,6 +1989,39 @@ export class LVGLWidget extends Widget {
                 );
             }
         }
+        if (this.hiddenFlagType == "expression") {
+            build.line(`{`);
+            build.indent();
+
+            build.line(
+                `bool val = ${build.getVariableGetterFunctionName(
+                    this.hiddenFlag as string
+                )}();`
+            );
+
+            build.line(`if (val) lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);`);
+            build.line(`else lv_obj_clear_flag(obj, LV_OBJ_FLAG_HIDDEN);`);
+
+            build.unindent();
+            build.line(`}`);
+        }
+
+        if (this.clickableFlagType == "expression") {
+            build.line(`{`);
+            build.indent();
+
+            build.line(
+                `bool val = ${build.getVariableGetterFunctionName(
+                    this.clickableFlag as string
+                )}();`
+            );
+
+            build.line(`if (val) lv_obj_add_flag(obj, LV_OBJ_FLAG_CLICKABLE);`);
+            build.line(`else lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICKABLE);`);
+
+            build.unindent();
+            build.line(`}`);
+        }
 
         if (this.flagScrollbarMode) {
             build.line(
@@ -2030,6 +2063,39 @@ export class LVGLWidget extends Widget {
                         .join("|")});`
                 );
             }
+        }
+        if (this.checkedStateType == "expression") {
+            build.line(`{`);
+            build.indent();
+
+            build.line(
+                `bool val = ${build.getVariableGetterFunctionName(
+                    this.checkedState as string
+                )}();`
+            );
+
+            build.line(`if (val) lv_obj_add_state(obj, LV_STATE_CHECKED);`);
+            build.line(`else lv_obj_clear_state(obj, LV_STATE_CHECKED);`);
+
+            build.unindent();
+            build.line(`}`);
+        }
+
+        if (this.disabledStateType == "expression") {
+            build.line(`{`);
+            build.indent();
+
+            build.line(
+                `bool val = ${build.getVariableGetterFunctionName(
+                    this.disabledState as string
+                )}();`
+            );
+
+            build.line(`if (val) lv_obj_add_state(obj, LV_STATE_DISABLED);`);
+            build.line(`else lv_obj_clear_state(obj, LV_STATE_DISABLED);`);
+
+            build.unindent();
+            build.line(`}`);
         }
 
         const useStyle = this.styleTemplate;

--- a/packages/project-editor/lvgl/widgets/Base.tsx
+++ b/packages/project-editor/lvgl/widgets/Base.tsx
@@ -1993,11 +1993,23 @@ export class LVGLWidget extends Widget {
             build.line(`{`);
             build.indent();
 
-            build.line(
-                `bool val = ${build.getVariableGetterFunctionName(
-                    this.hiddenFlag as string
-                )}();`
-            );
+            if (build.assets.projectStore.projectTypeTraits.hasFlowSupport) {
+                let componentIndex = build.assets.getComponentIndex(this);
+                const propertyIndex = build.assets.getComponentPropertyIndex(
+                    this,
+                    "hiddenFlag"
+                );
+
+                build.line(
+                    `bool val = evalBooleanProperty(flowState, ${componentIndex}, ${propertyIndex}, "Failed to evaluate Hidden flag");`
+                );
+            } else {
+                build.line(
+                    `bool val = ${build.getVariableGetterFunctionName(
+                        this.hiddenFlag as string
+                    )}();`
+                );
+            }
 
             build.line(`if (val) lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);`);
             build.line(`else lv_obj_clear_flag(obj, LV_OBJ_FLAG_HIDDEN);`);
@@ -2010,11 +2022,23 @@ export class LVGLWidget extends Widget {
             build.line(`{`);
             build.indent();
 
-            build.line(
-                `bool val = ${build.getVariableGetterFunctionName(
-                    this.clickableFlag as string
-                )}();`
-            );
+            if (build.assets.projectStore.projectTypeTraits.hasFlowSupport) {
+                let componentIndex = build.assets.getComponentIndex(this);
+                const propertyIndex = build.assets.getComponentPropertyIndex(
+                    this,
+                    "clickableFlag"
+                );
+
+                build.line(
+                    `bool val = evalBooleanProperty(flowState, ${componentIndex}, ${propertyIndex}, "Failed to evaluate Hidden flag");`
+                );
+            } else {
+                build.line(
+                    `bool val = ${build.getVariableGetterFunctionName(
+                        this.clickableFlag as string
+                    )}();`
+                );
+            }
 
             build.line(`if (val) lv_obj_add_flag(obj, LV_OBJ_FLAG_CLICKABLE);`);
             build.line(`else lv_obj_clear_flag(obj, LV_OBJ_FLAG_CLICKABLE);`);
@@ -2068,11 +2092,23 @@ export class LVGLWidget extends Widget {
             build.line(`{`);
             build.indent();
 
-            build.line(
-                `bool val = ${build.getVariableGetterFunctionName(
-                    this.checkedState as string
-                )}();`
-            );
+            if (build.assets.projectStore.projectTypeTraits.hasFlowSupport) {
+                let componentIndex = build.assets.getComponentIndex(this);
+                const propertyIndex = build.assets.getComponentPropertyIndex(
+                    this,
+                    "checkedState"
+                );
+
+                build.line(
+                    `bool val = evalBooleanProperty(flowState, ${componentIndex}, ${propertyIndex}, "Failed to evaluate Checked state");`
+                );
+            } else {
+                build.line(
+                    `bool val = ${build.getVariableGetterFunctionName(
+                        this.checkedState as string
+                    )}();`
+                );
+            }
 
             build.line(`if (val) lv_obj_add_state(obj, LV_STATE_CHECKED);`);
             build.line(`else lv_obj_clear_state(obj, LV_STATE_CHECKED);`);
@@ -2085,11 +2121,23 @@ export class LVGLWidget extends Widget {
             build.line(`{`);
             build.indent();
 
-            build.line(
-                `bool val = ${build.getVariableGetterFunctionName(
-                    this.disabledState as string
-                )}();`
-            );
+            if (build.assets.projectStore.projectTypeTraits.hasFlowSupport) {
+                let componentIndex = build.assets.getComponentIndex(this);
+                const propertyIndex = build.assets.getComponentPropertyIndex(
+                    this,
+                    "disabledState"
+                );
+
+                build.line(
+                    `bool val = evalBooleanProperty(flowState, ${componentIndex}, ${propertyIndex}, "Failed to evaluate Disabled state");`
+                );
+            } else {
+                build.line(
+                    `bool val = ${build.getVariableGetterFunctionName(
+                        this.disabledState as string
+                    )}();`
+                );
+            }
 
             build.line(`if (val) lv_obj_add_state(obj, LV_STATE_DISABLED);`);
             build.line(`else lv_obj_clear_state(obj, LV_STATE_DISABLED);`);


### PR DESCRIPTION
If the variable is only used in the tick function, screen switching may cause state flickering. Initially, the widget state is the default lvgl state, and it won't switch to the variable-specified state until the next tick, resulting in flickering.

Therefore, it's necessary to get the variable value and set the state once during screen creation.

As shown in the image below.
<img width="897" alt="截屏2024-11-22 16 25 46" src="https://github.com/user-attachments/assets/64d50e80-93d6-428a-a2ba-a340a9d69353">
