### PR TITLE
Fix inconsistent line endings of LVGL *.c images

### DIFF
--- a/packages/project-editor/lvgl/build.ts
+++ b/packages/project-editor/lvgl/build.ts
@@ -2446,6 +2446,11 @@ extern const ext_img_desc_t images[${this.bitmaps.length || 1}];
 #endif
 ${source}`;
 
+                            // ensure consistent newlines accross all platforms
+                            // (LF only) to avoid unnecessary VCS diffs
+                            source = source.replace(/\r\n/g, '\n');  // Windows
+                            source = source.replace(/\r/g, '\n');  // old Mac OS
+
                             await writeTextFile(
                                 this.project._store.getAbsoluteFilePath(
                                     destinationFolder


### PR DESCRIPTION
The generated LVGL image files (ui_image_*.c) had mixed LF and CRLF line endings on Windows, because a hardcoded header comes from `build.ts` (with always LF line endings) and the generated content comes from `LVGLImage.py` which uses native (i.e. platform dependent) line endings.

The real problem however is not the mixed line endings (it is just ugly, but not harmful). The problem is that the line endings are platform dependent. If a EEZ Studio project is worked on from multiple operating systems (e.g. multiple team members using different systems), every update of generated files will cause those line endings to change, creating a lot of unnecessary noise in the VCS. IMHO it is much cleaner to consistently use LF line endings on all platforms, which works fine and does not cause any VCS noise.

Just let me know if you wish any change of the implementation.