### PR TITLE
fix(codegen): replace part argument 0 with LV_PART_MAIN in generated lv_obj_get/set_style_* calls for LVGL 9.40+

### DIFF
--- a/packages/project-editor/lvgl/build.ts
+++ b/packages/project-editor/lvgl/build.ts
@@ -66,22 +66,22 @@ export class LVGLBuild extends Build {
         fromPage: LVGLWidget[];
         fromUserWidgets: Map<Page, LVGLWidget[]>;
     } = {
-        fromPage: [], // all pages share the same Set
-        fromUserWidgets: new Map() // different Set for each user widget
-    };
+            fromPage: [], // all pages share the same Set
+            fromUserWidgets: new Map() // different Set for each user widget
+        };
 
     lvglObjectIdentifiers: {
         fromPage: Identifiers;
         fromUserWidgets: Map<Page, Identifiers>;
     } = {
-        fromPage: {
-            identifiers: [],
-            widgetToIdentifier: new Map(),
-            widgetToAccessor: new Map(),
-            widgetToIndex: new Map()
-        },
-        fromUserWidgets: new Map()
-    };
+            fromPage: {
+                identifiers: [],
+                widgetToIdentifier: new Map(),
+                widgetToAccessor: new Map(),
+                widgetToIndex: new Map()
+            },
+            fromUserWidgets: new Map()
+        };
 
     fileStaticVars: {
         id: string;
@@ -190,7 +190,7 @@ export class LVGLBuild extends Build {
                 } else {
                     identifier =
                         this.assets.map.lvglWidgetGeneratedIdentifiers[
-                            widget.objID
+                        widget.objID
                         ];
 
                     if (!identifier) {
@@ -210,9 +210,8 @@ export class LVGLBuild extends Build {
                 pageIdentifiers.widgetToAccessor.set(
                     widget,
                     isUserWidget
-                        ? `((lv_obj_t **)&objects)[startWidgetIndex + ${
-                              pageIdentifiers.identifiers.length - startIndex
-                          }]`
+                        ? `((lv_obj_t **)&objects)[startWidgetIndex + ${pageIdentifiers.identifiers.length - startIndex
+                        }]`
                         : `objects.${prefix + identifier}`
                 );
 
@@ -228,8 +227,8 @@ export class LVGLBuild extends Build {
                     if (page) {
                         addIdentifiersForUserWidget(
                             prefix +
-                                identifier +
-                                USER_WIDGET_IDENTIFIER_SEPARATOR,
+                            identifier +
+                            USER_WIDGET_IDENTIFIER_SEPARATOR,
                             page,
                             pageIdentifiers
                         );
@@ -1545,14 +1544,12 @@ export class LVGLBuild extends Build {
 
             if (flag) {
                 build.line(
-                    `int startWidgetIndex = ${
-                        this.getWidgetObjectIndex(lvglWidget) + 1
+                    `int startWidgetIndex = ${this.getWidgetObjectIndex(lvglWidget) + 1
                     };`
                 );
             } else {
                 build.line(
-                    `startWidgetIndex += ${
-                        this.getWidgetObjectIndex(lvglWidget) + 1
+                    `startWidgetIndex += ${this.getWidgetObjectIndex(lvglWidget) + 1
                     };`
                 );
             }
@@ -1809,8 +1806,7 @@ export class LVGLBuild extends Build {
                 }
                 if (font.lvglFallbackFont) {
                     build.line(
-                        `${this.getFontVariableName(font)}->fallback = &${
-                            font.lvglFallbackFont
+                        `${this.getFontVariableName(font)}->fallback = &${font.lvglFallbackFont
                         };`
                     );
                 }
@@ -1872,8 +1868,7 @@ export class LVGLBuild extends Build {
 
         build.line("lv_disp_t *dispp = lv_disp_get_default();");
         build.line(
-            `lv_theme_t *theme = lv_theme_default_init(dispp, lv_palette_main(LV_PALETTE_BLUE), lv_palette_main(LV_PALETTE_RED), ${
-                this.project.settings.general.darkTheme ? "true" : "false"
+            `lv_theme_t *theme = lv_theme_default_init(dispp, lv_palette_main(LV_PALETTE_BLUE), lv_palette_main(LV_PALETTE_RED), ${this.project.settings.general.darkTheme ? "true" : "false"
             }, LV_FONT_DEFAULT);`
         );
         build.line("lv_disp_set_theme(dispp, theme);");
@@ -1912,11 +1907,10 @@ export class LVGLBuild extends Build {
 #define EXT_IMG_DESC_T
 typedef struct _ext_img_desc_t {
     const char *name;
-    const ${
-        this.project.settings.build.imageExportMode == "binary"
-            ? "void"
-            : "lv_img_dsc_t"
-    } *img_dsc;
+    const ${this.project.settings.build.imageExportMode == "binary"
+                ? "void"
+                : "lv_img_dsc_t"
+            } *img_dsc;
 } ext_img_desc_t;
 #endif
 
@@ -2101,10 +2095,9 @@ extern const ext_img_desc_t images[${this.bitmaps.length || 1}];
                 variable.native
             ) {
                 build.line(
-                    `{ NATIVE_VAR_TYPE_${
-                        isEnumType(variable.type)
-                            ? "INTEGER"
-                            : variable.type.toUpperCase()
+                    `{ NATIVE_VAR_TYPE_${isEnumType(variable.type)
+                        ? "INTEGER"
+                        : variable.type.toUpperCase()
                     }, ${this.getVariableGetterFunctionName(
                         variable.name
                     )}, ${this.getVariableSetterFunctionName(
@@ -2189,7 +2182,7 @@ extern const ext_img_desc_t images[${this.bitmaps.length || 1}];
 
                             if (
                                 lvglStyle.parentStyle?.fullDefinition?.[part]?.[
-                                    state
+                                state
                                 ]
                             ) {
                                 build.line(
@@ -2420,13 +2413,13 @@ extern const ext_img_desc_t images[${this.bitmaps.length || 1}];
                                 this.project._store.getAbsoluteFilePath(
                                     destinationFolder
                                 ) +
-                                    "/" +
-                                    (this.project.settings.build
-                                        .separateFolderForImagesAndFonts
-                                        ? "images/"
-                                        : "") +
-                                    output +
-                                    ".bin",
+                                "/" +
+                                (this.project.settings.build
+                                    .separateFolderForImagesAndFonts
+                                    ? "images/"
+                                    : "") +
+                                output +
+                                ".bin",
                                 Buffer.from(source)
                             );
                         } catch (err) {
@@ -2465,13 +2458,13 @@ ${source}`;
                                 this.project._store.getAbsoluteFilePath(
                                     destinationFolder
                                 ) +
-                                    "/" +
-                                    (this.project.settings.build
-                                        .separateFolderForImagesAndFonts
-                                        ? "images/"
-                                        : "") +
-                                    output +
-                                    ".c",
+                                "/" +
+                                (this.project.settings.build
+                                    .separateFolderForImagesAndFonts
+                                    ? "images/"
+                                    : "") +
+                                output +
+                                ".c",
                                 source
                             );
                         } catch (err) {
@@ -2522,13 +2515,13 @@ ${source}`;
                                     this.project._store.getAbsoluteFilePath(
                                         destinationFolder
                                     ) +
-                                        "/" +
-                                        (this.project.settings.build
-                                            .separateFolderForImagesAndFonts
-                                            ? "fonts/"
-                                            : "") +
-                                        output +
-                                        ".bin",
+                                    "/" +
+                                    (this.project.settings.build
+                                        .separateFolderForImagesAndFonts
+                                        ? "fonts/"
+                                        : "") +
+                                    output +
+                                    ".bin",
                                     lvglBinaryFile
                                 );
                             } catch (err) {
@@ -2553,13 +2546,13 @@ ${source}`;
                                     this.project._store.getAbsoluteFilePath(
                                         destinationFolder
                                     ) +
-                                        "/" +
-                                        (this.project.settings.build
-                                            .separateFolderForImagesAndFonts
-                                            ? "fonts/"
-                                            : "") +
-                                        output +
-                                        ".c",
+                                    "/" +
+                                    (this.project.settings.build
+                                        .separateFolderForImagesAndFonts
+                                        ? "fonts/"
+                                        : "") +
+                                    output +
+                                    ".c",
                                     lvglSourceFile
                                 );
                             } catch (err) {
@@ -2584,27 +2577,27 @@ export async function generateSourceCodeForEezFramework(
 ) {
     try {
         await fs.promises.rm(destinationFolderPath + "/eez-flow.cpp");
-    } catch (err) {}
+    } catch (err) { }
 
     try {
         await fs.promises.rm(destinationFolderPath + "/eez-flow.h");
-    } catch (err) {}
+    } catch (err) { }
 
     try {
         await fs.promises.rm(destinationFolderPath + "/eez-flow-lz4.c");
-    } catch (err) {}
+    } catch (err) { }
 
     try {
         await fs.promises.rm(destinationFolderPath + "/eez-flow-lz4.h");
-    } catch (err) {}
+    } catch (err) { }
 
     try {
         await fs.promises.rm(destinationFolderPath + "/eez-flow-sha256.c");
-    } catch (err) {}
+    } catch (err) { }
 
     try {
         await fs.promises.rm(destinationFolderPath + "/eez-flow-sha256.h");
-    } catch (err) {}
+    } catch (err) { }
 
     if (
         !(
@@ -2628,7 +2621,7 @@ export async function generateSourceCodeForEezFramework(
             structs_H,
             "utf-8"
         );
-    } catch (err) {}
+    } catch (err) { }
 
     // post fix ui.h
     try {
@@ -2645,7 +2638,7 @@ export async function generateSourceCodeForEezFramework(
             ui_H,
             "utf-8"
         );
-    } catch (err) {}
+    } catch (err) { }
 
     const eezframeworkAmalgamationPath = isDev
         ? resolve(`${sourceRootDir()}/../resources/eez-framework-amalgamation`)
@@ -2660,6 +2653,36 @@ export async function generateSourceCodeForEezFramework(
         eezframeworkAmalgamationPath + "/eez-flow.h",
         destinationFolderPath + "/eez-flow.h"
     );
+
+    // Post-fix eez-flow.cpp for LVGL 9.40+ API changes where part is lv_part_t
+    try {
+        let eezCPP = await fs.promises.readFile(
+            destinationFolderPath + "/eez-flow.cpp",
+            "utf-8"
+        );
+
+        // Replace lv_obj_get_style_* calls that pass integer 0 as part with LV_PART_MAIN
+        // Example: lv_obj_get_style_opa(obj, 0) -> lv_obj_get_style_opa(obj, LV_PART_MAIN)
+        eezCPP = eezCPP.replace(
+            /lv_obj_get_style_([a-zA-Z0-9_]+)\s*\(([^,]+),\s*0\s*\)/g,
+            (match, prop, objExpr) => `lv_obj_get_style_${prop}(${objExpr}, LV_PART_MAIN)`
+        );
+
+        // Replace lv_obj_set_style_* calls that pass integer 0 as part with LV_PART_MAIN
+        // Example: lv_obj_set_style_bg_opa(obj, value, 0) -> lv_obj_set_style_bg_opa(obj, value, LV_PART_MAIN)
+        eezCPP = eezCPP.replace(
+            /lv_obj_set_style_([a-zA-Z0-9_]+)\s*\(([^,]+),\s*([^,]+),\s*0\s*\)/g,
+            (match, prop, objExpr, valExpr) => `lv_obj_set_style_${prop}(${objExpr}, ${valExpr}, LV_PART_MAIN)`
+        );
+
+        await fs.promises.writeFile(
+            destinationFolderPath + "/eez-flow.cpp",
+            eezCPP,
+            "utf-8"
+        );
+    } catch (err) {
+        // If anything goes wrong, leave the original as-is
+    }
 
     let eezH = await fs.promises.readFile(
         destinationFolderPath + "/eez-flow.h",
@@ -2703,13 +2726,13 @@ export async function generateSourceCodeForEezFramework(
     eezH = eezH.replace(
         "#define EEZ_FLOW_QUEUE_SIZE 1000",
         "#define EEZ_FLOW_QUEUE_SIZE " +
-            project.settings.build.executionQueueSize
+        project.settings.build.executionQueueSize
     );
 
     eezH = eezH.replace(
         "#define EEZ_FLOW_EVAL_STACK_SIZE 20",
         "#define EEZ_FLOW_EVAL_STACK_SIZE " +
-            project.settings.build.expressionEvaluatorStackSize
+        project.settings.build.expressionEvaluatorStackSize
     );
 
     eezH = eezH.replace(


### PR DESCRIPTION

LVGL ≥9.40 changed the second parameter of style get/set helpers from int to lv_part_t. The previous code generator emitted calls like lv_obj_get_style_opa(obj, 0) which now fail with: invalid conversion from 'int' to 'lv_part_t'. Added a post‑processing step in [build.ts](vscode-file://vscode-app/c:/Users/regte/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that rewrites any generated lv_obj_get_style_* and lv_obj_set_style_* calls using part 0 to LV_PART_MAIN. Backwards compatible with LVGL 8 (LV_PART_MAIN == 0).

i tested by building EEZ Studio and installing, Generated c files, and it work with arduino 9.40 out of box :)