### PR TITLE
Add MicroPython code generation support for LVGL 9.x

### DIFF
--- a/packages/project-editor/build/assets.ts
+++ b/packages/project-editor/build/assets.ts
@@ -1867,6 +1867,9 @@ export async function buildAssets(
 
     result.EEZ_FLOW_IS_USING_CRYPTO_SHA256 = assets.isUsingCrypyoSha256;
 
+    // Include assets object for MicroPython build
+    result.assets = assets;
+
     return Object.assign(
         result,
         await buildVariables(assets, sectionNames),

--- a/packages/project-editor/lvgl/micropython-build.ts
+++ b/packages/project-editor/lvgl/micropython-build.ts
@@ -1,0 +1,856 @@
+import {
+    NamingConvention,
+    getName,
+    Build
+} from "project-editor/build/helper";
+import type { Bitmap } from "project-editor/features/bitmap/bitmap";
+import type { Font } from "project-editor/features/font/font";
+import { Page } from "project-editor/features/page/page";
+import { ProjectEditor } from "project-editor/project-editor-interface";
+import { Project } from "project-editor/project/project";
+import { getAncestorOfType } from "project-editor/store";
+import type { LVGLWidget } from "./widgets";
+import type { Assets } from "project-editor/build/assets";
+import type { LVGLStyle } from "project-editor/lvgl/style";
+import type { IEezObject } from "project-editor/core/object";
+import { MicroPythonLVGLCode } from "project-editor/lvgl/to-micropython-code";
+import { GENERATED_NAME_PREFIX } from "./identifiers";
+import { isGeometryControlledByParent } from "./widget-common";
+
+interface Identifiers {
+    identifiers: string[];
+    widgetToIdentifier: Map<LVGLWidget, string>;
+    widgetToAccessor: Map<LVGLWidget, string>;
+    widgetToIndex: Map<LVGLWidget, number>;
+}
+
+/**
+ * MicroPython LVGL 9.x Build System
+ *
+ * Generates MicroPython code compatible with lv_micropython bindings.
+ * Output is a single .py file that can be run on MicroPython with LVGL support.
+ */
+export class MicroPythonLVGLBuild extends Build {
+    project: Project;
+
+    toMicroPythonCode = new MicroPythonLVGLCode(this);
+
+    styleNames = new Map<string, string>();
+    fontNames = new Map<string, string>();
+    bitmapNames = new Map<string, string>();
+
+    updateColorCallbacks: {
+        object: IEezObject;
+        callback: () => void;
+    }[] = [];
+
+    isFirstPass: boolean;
+
+    buildObjectsAccessibleFromSourceCode: {
+        fromPage: LVGLWidget[];
+        fromUserWidgets: Map<Page, LVGLWidget[]>;
+    } = {
+        fromPage: [],
+        fromUserWidgets: new Map()
+    };
+
+    lvglObjectIdentifiers: {
+        fromPage: Identifiers;
+        fromUserWidgets: Map<Page, Identifiers>;
+    } = {
+        fromPage: {
+            identifiers: [],
+            widgetToIdentifier: new Map(),
+            widgetToAccessor: new Map(),
+            widgetToIndex: new Map()
+        },
+        fromUserWidgets: new Map()
+    };
+
+    fileStaticVars: {
+        id: string;
+        decl: string;
+        varName: string;
+        page: Page;
+    }[] = [];
+
+    objectAccessors: string[] | undefined;
+    currentPage: Page;
+
+    tickCallbacks: (() => void)[];
+    eventHandlers = new Map<LVGLWidget, (() => void)[]>();
+    postBuildCallbacks: (() => void)[] = [];
+
+    // Python-specific indentation tracking
+    private indentLevel = 0;
+    private readonly INDENT = "    "; // 4 spaces for Python
+
+    constructor(public assets: Assets) {
+        super();
+
+        this.project = assets.projectStore.project;
+
+        this.buildStyleNames();
+        this.buildFontNames();
+        this.buildBitmapNames();
+    }
+
+    //--------------------------------------------------------------------------
+    // Build phases
+    //--------------------------------------------------------------------------
+
+    async firtsPassStart() {
+        this.isFirstPass = true;
+
+        for (const page of this.pages) {
+            if (!page.isUsedAsUserWidget) {
+                this.markObjectAccessibleFromSourceCode(page.lvglScreenWidget!);
+            }
+        }
+    }
+
+    async firstPassFinish() {
+        await this.buildScreensDef();
+        await this.buildStylesDef();
+
+        this.finalizeObjectAccessibleFromSourceCodeTable();
+        this.isFirstPass = false;
+        this.updateColorCallbacks = [];
+    }
+
+    markObjectAccessibleFromSourceCode(widget: LVGLWidget) {
+        const page = getAncestorOfType(
+            widget,
+            ProjectEditor.PageClass.classInfo
+        ) as Page;
+
+        if (page.isUsedAsUserWidget) {
+            let widgets =
+                this.buildObjectsAccessibleFromSourceCode.fromUserWidgets.get(
+                    page
+                );
+
+            if (!widgets) {
+                widgets = [];
+                this.buildObjectsAccessibleFromSourceCode.fromUserWidgets.set(
+                    page,
+                    widgets
+                );
+            }
+
+            if (!widgets.includes(widget)) {
+                widgets.push(widget);
+            }
+        } else {
+            if (
+                !this.buildObjectsAccessibleFromSourceCode.fromPage.includes(
+                    widget
+                )
+            ) {
+                this.buildObjectsAccessibleFromSourceCode.fromPage.push(widget);
+            }
+        }
+    }
+
+    finalizeObjectAccessibleFromSourceCodeTable() {
+        let genIndex = 0;
+
+        const generateUniqueObjectName = () => {
+            return GENERATED_NAME_PREFIX + genIndex++;
+        };
+
+        const addPageIdentifiers = (
+            widgets: LVGLWidget[],
+            pageIdentifiers: Identifiers,
+            prefix: string,
+            isUserWidget: boolean
+        ) => {
+            let startIndex = isUserWidget
+                ? pageIdentifiers.identifiers.length
+                : 0;
+
+            for (const widget of widgets) {
+                let identifier;
+
+                if (widget.identifier) {
+                    identifier = getName(
+                        "",
+                        widget.identifier,
+                        NamingConvention.UnderscoreLowerCase
+                    );
+                } else {
+                    identifier =
+                        this.assets.map.lvglWidgetGeneratedIdentifiers[
+                            widget.objID
+                        ];
+
+                    if (!identifier) {
+                        identifier = generateUniqueObjectName();
+                        this.assets.map.lvglWidgetGeneratedIdentifiers[
+                            widget.objID
+                        ] = identifier;
+                    }
+                }
+
+                pageIdentifiers.widgetToIdentifier.set(
+                    widget,
+                    prefix + identifier
+                );
+
+                // Python accessor format
+                pageIdentifiers.widgetToAccessor.set(
+                    widget,
+                    isUserWidget
+                        ? `objects[start_widget_index + ${
+                              pageIdentifiers.identifiers.length - startIndex
+                          }]`
+                        : `objects["${prefix + identifier}"]`
+                );
+
+                pageIdentifiers.widgetToIndex.set(
+                    widget,
+                    pageIdentifiers.identifiers.length - startIndex
+                );
+
+                pageIdentifiers.identifiers.push(prefix + identifier);
+            }
+        };
+
+        for (const page of this.pages) {
+            if (!page.isUsedAsUserWidget) {
+                const identifier = getName(
+                    "",
+                    page.name,
+                    NamingConvention.UnderscoreLowerCase
+                );
+
+                this.lvglObjectIdentifiers.fromPage.widgetToIdentifier.set(
+                    page.lvglScreenWidget!,
+                    identifier
+                );
+
+                this.lvglObjectIdentifiers.fromPage.widgetToAccessor.set(
+                    page.lvglScreenWidget!,
+                    `objects["${identifier}"]`
+                );
+
+                this.lvglObjectIdentifiers.fromPage.widgetToIndex.set(
+                    page.lvglScreenWidget!,
+                    this.lvglObjectIdentifiers.fromPage.identifiers.length
+                );
+
+                this.lvglObjectIdentifiers.fromPage.identifiers.push(
+                    identifier
+                );
+            } else {
+                const widgets =
+                    this.buildObjectsAccessibleFromSourceCode.fromUserWidgets.get(
+                        page
+                    ) ?? [];
+
+                let pageIdentifiers: Identifiers = {
+                    identifiers: [],
+                    widgetToIdentifier: new Map(),
+                    widgetToAccessor: new Map(),
+                    widgetToIndex: new Map()
+                };
+
+                addPageIdentifiers(widgets, pageIdentifiers, "", true);
+
+                this.lvglObjectIdentifiers.fromUserWidgets.set(
+                    page,
+                    pageIdentifiers
+                );
+            }
+        }
+
+        genIndex = 0;
+
+        const widgets =
+            this.buildObjectsAccessibleFromSourceCode.fromPage.filter(
+                widget =>
+                    !this.lvglObjectIdentifiers.fromPage.widgetToIdentifier.get(
+                        widget
+                    )
+            );
+
+        addPageIdentifiers(
+            widgets,
+            this.lvglObjectIdentifiers.fromPage,
+            "",
+            false
+        );
+    }
+
+    isAccessibleFromSourceCode(widget: LVGLWidget) {
+        if (widget.identifier) {
+            return true;
+        }
+
+        let page = getAncestorOfType(
+            widget,
+            ProjectEditor.PageClass.classInfo
+        ) as Page;
+
+        if (page.isUsedAsUserWidget) {
+            return (
+                this.buildObjectsAccessibleFromSourceCode.fromUserWidgets
+                    .get(page)
+                    ?.includes(widget) ?? false
+            );
+        }
+
+        return this.buildObjectsAccessibleFromSourceCode.fromPage.includes(
+            widget
+        );
+    }
+
+    //--------------------------------------------------------------------------
+    // Accessors
+    //--------------------------------------------------------------------------
+
+    get pages() {
+        return this.project._store.lvglIdentifiers.pages;
+    }
+
+    get userPages() {
+        return this.project._store.lvglIdentifiers.userPages;
+    }
+
+    get styles() {
+        return this.project._store.lvglIdentifiers.styles;
+    }
+
+    get fonts() {
+        return this.project._store.lvglIdentifiers.fonts;
+    }
+
+    get bitmaps() {
+        return this.project._store.lvglIdentifiers.bitmaps;
+    }
+
+    get isV9() {
+        return true; // MicroPython targets LVGL 9.x
+    }
+
+    //--------------------------------------------------------------------------
+    // Name building
+    //--------------------------------------------------------------------------
+
+    buildStyleNames() {
+        const names = new Set<string>();
+
+        for (const style of this.styles) {
+            let name = getName("", style, NamingConvention.UnderscoreLowerCase);
+
+            if (names.has(name)) {
+                for (let i = 1; ; i++) {
+                    const newName = name + i.toString();
+                    if (!names.has(newName)) {
+                        name = newName;
+                        break;
+                    }
+                }
+            }
+
+            this.styleNames.set(style.objID, name);
+            names.add(name);
+        }
+    }
+
+    buildFontNames() {
+        const names = new Set<string>();
+
+        for (const font of this.fonts) {
+            let name = getName("", font, NamingConvention.UnderscoreLowerCase);
+
+            if (names.has(name)) {
+                for (let i = 1; ; i++) {
+                    const newName = name + i.toString();
+                    if (!names.has(newName)) {
+                        name = newName;
+                        break;
+                    }
+                }
+            }
+
+            this.fontNames.set(font.objID, name);
+            names.add(name);
+        }
+    }
+
+    buildBitmapNames() {
+        const names = new Set<string>();
+
+        for (const bitmap of this.bitmaps) {
+            let name = getName(
+                "",
+                bitmap,
+                NamingConvention.UnderscoreLowerCase
+            );
+
+            if (names.has(name)) {
+                for (let i = 1; ; i++) {
+                    const newName = name + i.toString();
+                    if (!names.has(newName)) {
+                        name = newName;
+                        break;
+                    }
+                }
+            }
+
+            this.bitmapNames.set(bitmap.objID, name);
+            names.add(name);
+        }
+    }
+
+    getStyleName(style: LVGLStyle) {
+        return this.styleNames.get(style.objID) || "unknown_style";
+    }
+
+    getFontName(font: Font) {
+        return this.fontNames.get(font.objID) || "unknown_font";
+    }
+
+    getBitmapName(bitmap: Bitmap) {
+        return this.bitmapNames.get(bitmap.objID) || "unknown_bitmap";
+    }
+
+    getScreenIdentifier(page: Page) {
+        return getName("", page, NamingConvention.UnderscoreLowerCase);
+    }
+
+    getScreenCreateFunctionName(page: Page) {
+        return page.isUsedAsUserWidget
+            ? `create_user_widget_${this.getScreenIdentifier(page)}`
+            : `create_screen_${this.getScreenIdentifier(page)}`;
+    }
+
+    getScreenTickFunctionName(page: Page) {
+        return page.isUsedAsUserWidget
+            ? `tick_user_widget_${this.getScreenIdentifier(page)}`
+            : `tick_screen_${this.getScreenIdentifier(page)}`;
+    }
+
+    getActionFunctionName(actionName: string) {
+        return getName(
+            "action_",
+            actionName,
+            NamingConvention.UnderscoreLowerCase
+        );
+    }
+
+    getVariableGetterFunctionName(variableName: string) {
+        return getName(
+            "get_var_",
+            variableName,
+            NamingConvention.UnderscoreLowerCase
+        );
+    }
+
+    getVariableSetterFunctionName(variableName: string) {
+        return getName(
+            "set_var_",
+            variableName,
+            NamingConvention.UnderscoreLowerCase
+        );
+    }
+
+    getLvglObjectAccessor(widget: LVGLWidget): string {
+        const page = getAncestorOfType(
+            widget,
+            ProjectEditor.PageClass.classInfo
+        ) as Page;
+
+        if (page.isUsedAsUserWidget) {
+            const pageIdentifiers =
+                this.lvglObjectIdentifiers.fromUserWidgets.get(page);
+            if (pageIdentifiers) {
+                return (
+                    pageIdentifiers.widgetToAccessor.get(widget) || "None"
+                );
+            }
+        }
+
+        return (
+            this.lvglObjectIdentifiers.fromPage.widgetToAccessor.get(widget) ||
+            "None"
+        );
+    }
+
+    getImageAccessor(bitmap: Bitmap) {
+        return `img_${this.getBitmapName(bitmap)}`;
+    }
+
+    //--------------------------------------------------------------------------
+    // Python-specific output methods (override Build class)
+    //--------------------------------------------------------------------------
+
+    override line(text: string = "") {
+        if (text) {
+            super.line(this.INDENT.repeat(this.indentLevel) + text);
+        } else {
+            super.line("");
+        }
+    }
+
+    override blockStart(text: string) {
+        this.line(text);
+        this.indentLevel++;
+    }
+
+    override blockEnd(text: string) {
+        this.indentLevel--;
+        if (text) {
+            this.line(text);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Widget building helpers
+    //--------------------------------------------------------------------------
+
+    buildWidgetAssign(widget: LVGLWidget) {
+        if (this.isAccessibleFromSourceCode(widget)) {
+            const identifier =
+                this.lvglObjectIdentifiers.fromPage.widgetToIdentifier.get(
+                    widget
+                );
+            if (identifier) {
+                this.line(`objects["${identifier}"] = obj`);
+            }
+        }
+    }
+
+    buildWidgetSetPosAndSize(widget: LVGLWidget) {
+        if (widget instanceof ProjectEditor.LVGLScreenWidgetClass) {
+            const page = getAncestorOfType(
+                widget,
+                ProjectEditor.PageClass.classInfo
+            ) as Page;
+
+            this.line(`obj.set_pos(${page.left}, ${page.top})`);
+            this.line(`obj.set_size(${page.width}, ${page.height})`);
+        } else if (isGeometryControlledByParent(widget)) {
+            // skip
+        } else {
+            this.line(
+                `obj.set_pos(${widget.lvglBuildLeft}, ${widget.lvglBuildTop})`
+            );
+            this.line(
+                `obj.set_size(${widget.lvglBuildWidth}, ${widget.lvglBuildHeight})`
+            );
+        }
+    }
+
+    assignToObjectsStruct(accessor: string) {
+        // For Python, we store in a dict
+        this.line(`${accessor} = obj`);
+    }
+
+    //--------------------------------------------------------------------------
+    // Tick and event callbacks
+    //--------------------------------------------------------------------------
+
+    addTickCallback(callback: () => void) {
+        if (!this.tickCallbacks) {
+            this.tickCallbacks = [];
+        }
+        this.tickCallbacks.push(callback);
+    }
+
+    addEventHandler(widget: LVGLWidget, callback: () => void) {
+        let eventHandlers = this.eventHandlers.get(widget);
+        if (!eventHandlers) {
+            eventHandlers = [];
+            this.eventHandlers.set(widget, eventHandlers);
+        }
+        eventHandlers.push(callback);
+    }
+
+    postBuildStart() {
+        this.postBuildCallbacks = [];
+    }
+
+    postBuildAdd(callback: () => void) {
+        this.postBuildCallbacks.push(callback);
+    }
+
+    postBuildEnd() {
+        for (const callback of this.postBuildCallbacks) {
+            callback();
+        }
+        this.postBuildCallbacks = [];
+    }
+
+    //--------------------------------------------------------------------------
+    // Color handling
+    //--------------------------------------------------------------------------
+
+    buildColor<T>(
+        object: IEezObject,
+        color: string,
+        getParams: () => T,
+        callback: (color: string, params: T) => void,
+        updateCallback: (color: any, params: T) => void
+    ) {
+        const params = getParams();
+        callback(color, params);
+    }
+
+    buildColor2<T>(
+        object: IEezObject,
+        color1: string,
+        color2: string,
+        getParams: () => T,
+        callback: (color1: string, color2: string, params: T) => void,
+        updateCallback: (color1: any, color2: any, params: T) => void
+    ) {
+        const params = getParams();
+        callback(color1, color2, params);
+    }
+
+    getColorHexStr(color: string): string {
+        // Convert color to hex format for Python
+        if (color.startsWith("#")) {
+            return `0x${color.substring(1).toUpperCase()}`;
+        }
+        return color;
+    }
+
+    //--------------------------------------------------------------------------
+    // Static variables
+    //--------------------------------------------------------------------------
+
+    genFileStaticVar(id: string, type: string, prefixName: string): string {
+        const existing = this.fileStaticVars.find(v => v.id === id);
+        if (existing) {
+            return existing.varName;
+        }
+
+        const varName = `${prefixName}_${this.fileStaticVars.length}`;
+        this.fileStaticVars.push({
+            id,
+            decl: `${varName} = None`,
+            varName,
+            page: this.currentPage
+        });
+
+        return varName;
+    }
+
+    assingToFileStaticVar(varName: string, value: string) {
+        this.line(`${varName} = ${value}`);
+    }
+
+    //--------------------------------------------------------------------------
+    // Main build methods
+    //--------------------------------------------------------------------------
+
+    async buildScreensDef() {
+        // Build screen definitions - this is called during first pass
+        // The actual output is generated later
+    }
+
+    async buildStylesDef() {
+        // Build style definitions - this is called during first pass
+    }
+
+    /**
+     * Generate the complete MicroPython file
+     */
+    async generateMicroPythonFile(): Promise<string> {
+        this.startBuild();
+
+        // Header
+        this.line("# Generated by EEZ Studio");
+        this.line("# MicroPython LVGL 9.x Code");
+        this.line("# https://github.com/eez-open/studio");
+        this.line("");
+        this.line("import lvgl as lv");
+        this.line("");
+
+        // Global objects dictionary
+        this.line("# Global objects storage");
+        this.line("objects = {}");
+        this.line("tick_value_change_obj = None");
+        this.line("");
+
+        // Static variables
+        if (this.fileStaticVars.length > 0) {
+            this.line("# Static variables");
+            this.fileStaticVars.forEach(v => this.line(v.decl));
+            this.line("");
+        }
+
+        // Styles
+        await this.generateStyles();
+
+        // Screen creation functions
+        await this.generateScreenFunctions();
+
+        // Tick functions
+        await this.generateTickFunctions();
+
+        // Main create_screens function
+        await this.generateCreateScreens();
+
+        return this.result;
+    }
+
+    private async generateStyles() {
+        if (this.styles.length === 0) return;
+
+        this.line("# Styles");
+        this.line("styles = {}");
+        this.line("");
+
+        this.blockStart("def init_styles():");
+        this.line("global styles");
+
+        for (const style of this.styles) {
+            const styleName = this.getStyleName(style);
+            this.line("");
+            this.line(`# Style: ${style.name}`);
+            this.line(`styles["${styleName}"] = lv.style_t()`);
+            this.line(`styles["${styleName}"].init()`);
+
+            // Generate style properties
+            // This would need to be expanded based on the actual style properties
+        }
+
+        this.blockEnd("");
+        this.line("");
+    }
+
+    private async generateScreenFunctions() {
+        this.line("# Screen creation functions");
+        this.line("");
+
+        for (const page of this.pages) {
+            if (page.isUsedAsUserWidget) continue;
+
+            this.currentPage = page;
+            const funcName = this.getScreenCreateFunctionName(page);
+
+            this.blockStart(`def ${funcName}():`);
+            this.line("global objects");
+            this.line("");
+
+            // Create screen
+            this.line("# Create screen");
+            this.line("obj = lv.obj(None)");
+
+            const screenIdentifier = this.getScreenIdentifier(page);
+            this.line(`objects["${screenIdentifier}"] = obj`);
+            this.line(`obj.set_size(${page.width}, ${page.height})`);
+            this.line("");
+
+            // Build widgets
+            if (page.lvglScreenWidget) {
+                this.line("parent_obj = obj");
+                await this.buildWidgets(page.lvglScreenWidget);
+            }
+
+            this.blockEnd("");
+            this.line("");
+        }
+    }
+
+    private async buildWidgets(widget: LVGLWidget) {
+        // Build child widgets
+        const children = widget.children as LVGLWidget[];
+        if (children) {
+            for (const child of children) {
+                this.toMicroPythonCode.startWidget(child);
+
+                // Let the widget build itself
+                if (typeof (child as any).lvglBuildObj === "function") {
+                    (child as any).lvglBuildObj(this.toMicroPythonCode);
+                }
+
+                this.toMicroPythonCode.endWidget();
+
+                // Recursively build children
+                await this.buildWidgets(child);
+            }
+        }
+    }
+
+    private async generateTickFunctions() {
+        this.line("# Tick functions");
+        this.line("");
+
+        for (const page of this.pages) {
+            if (page.isUsedAsUserWidget) continue;
+
+            const funcName = this.getScreenTickFunctionName(page);
+
+            this.blockStart(`def ${funcName}():`);
+            this.line("global objects, tick_value_change_obj");
+
+            if (this.tickCallbacks && this.tickCallbacks.length > 0) {
+                for (const callback of this.tickCallbacks) {
+                    callback();
+                }
+            } else {
+                this.line("pass  # No tick operations");
+            }
+
+            this.blockEnd("");
+            this.line("");
+        }
+    }
+
+    private async generateCreateScreens() {
+        this.line("# Main initialization");
+        this.line("");
+
+        this.blockStart("def create_screens():");
+
+        // Initialize styles
+        if (this.styles.length > 0) {
+            this.line("init_styles()");
+            this.line("");
+        }
+
+        // Initialize display and theme
+        this.line("# Initialize display theme");
+        this.line("disp = lv.display.get_default()");
+        this.line(
+            `theme = lv.theme_default_init(disp, lv.palette_main(lv.PALETTE.BLUE), lv.palette_main(lv.PALETTE.RED), ${
+                this.project.settings.general.darkTheme ? "True" : "False"
+            }, lv.font_default())`
+        );
+        this.line("disp.set_theme(theme)");
+        this.line("");
+
+        // Create screens
+        this.line("# Create screens");
+        for (const page of this.userPages) {
+            if (page.createAtStart || !this.project.settings.build.screensLifetimeSupport) {
+                this.line(`${this.getScreenCreateFunctionName(page)}()`);
+            }
+        }
+
+        this.blockEnd("");
+        this.line("");
+
+        // Entry point
+        this.line("# Entry point");
+        this.line("if __name__ == '__main__':");
+        this.line("    create_screens()");
+    }
+}
+
+/**
+ * Build MicroPython code for an LVGL project
+ */
+export async function buildMicroPythonLVGL(assets: Assets): Promise<string> {
+    const build = new MicroPythonLVGLBuild(assets);
+
+    await build.firtsPassStart();
+    await build.firstPassFinish();
+
+    return await build.generateMicroPythonFile();
+}

--- a/packages/project-editor/lvgl/to-micropython-code.ts
+++ b/packages/project-editor/lvgl/to-micropython-code.ts
@@ -1,0 +1,683 @@
+import type { IEezObject } from "project-editor/core/object";
+import { ProjectEditor } from "project-editor/project-editor-interface";
+import { findBitmap } from "project-editor/project/project";
+
+import type { LVGLWidget } from "project-editor/lvgl/widgets";
+import type { LVGLCode } from "project-editor/lvgl/to-lvgl-code";
+import type { MicroPythonLVGLBuild } from "project-editor/lvgl/micropython-build";
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * MicroPython LVGL 9.x code generator
+ *
+ * This class implements the LVGLCode interface to generate MicroPython code
+ * compatible with lv_micropython bindings for LVGL 9.x
+ *
+ * API Mapping (C -> MicroPython):
+ * - lv_obj_create(parent) -> lv.obj(parent)
+ * - lv_btn_create(parent) -> lv.button(parent)
+ * - lv_obj_set_pos(obj, x, y) -> obj.set_pos(x, y)
+ * - lv_obj_set_size(obj, w, h) -> obj.set_size(w, h)
+ * - lv_style_set_bg_color(style, color) -> style.set_bg_color(color)
+ * - LV_ALIGN_CENTER -> lv.ALIGN.CENTER
+ * - lv_color_hex(0xFF0000) -> lv.color_hex(0xFF0000)
+ */
+export class MicroPythonLVGLCode implements LVGLCode {
+    constructor(public build: MicroPythonLVGLBuild) {}
+
+    widget: LVGLWidget;
+
+    isTick = false;
+    componentIndex: number;
+    propertyIndex: number;
+
+    noGoodNameCallbacks: (() => void)[] = [];
+
+    startWidget(widget: LVGLWidget) {
+        this.widget = widget;
+    }
+
+    endWidget() {
+        for (const callback of this.noGoodNameCallbacks) {
+            callback();
+        }
+        this.noGoodNameCallbacks = [];
+    }
+
+    get project() {
+        return this.build.project;
+    }
+
+    get pageRuntime() {
+        return undefined;
+    }
+
+    get lvglBuild() {
+        return this.build as any;
+    }
+
+    get isV9(): boolean {
+        return true; // MicroPython support targets LVGL 9.x
+    }
+
+    get hasFlowSupport() {
+        return false; // Flow support not implemented for MicroPython yet
+    }
+
+    get screensLifetimeSupport() {
+        return this.build.project.settings.build.screensLifetimeSupport;
+    }
+
+    //--------------------------------------------------------------------------
+    // Constants and literals
+    //--------------------------------------------------------------------------
+
+    constant(constant: string) {
+        // Convert C constants to MicroPython format
+        // LV_ALIGN_CENTER -> lv.ALIGN.CENTER
+        // LV_STATE_DEFAULT -> lv.STATE.DEFAULT
+        // LV_PART_MAIN -> lv.PART.MAIN
+        return this.convertConstant(constant);
+    }
+
+    private convertConstant(constant: string): string {
+        if (!constant) return constant;
+
+        // Handle multiple constants OR'd together
+        if (constant.includes(" | ")) {
+            return constant
+                .split(" | ")
+                .map(c => this.convertSingleConstant(c.trim()))
+                .join(" | ");
+        }
+
+        return this.convertSingleConstant(constant);
+    }
+
+    private convertSingleConstant(constant: string): string {
+        // Skip if already converted or is a number
+        if (!constant.startsWith("LV_")) {
+            return constant;
+        }
+
+        // LV_ALIGN_CENTER -> lv.ALIGN.CENTER
+        // LV_STATE_DEFAULT -> lv.STATE.DEFAULT
+        // LV_OPA_50 -> lv.OPA._50
+        // LV_FLEX_FLOW_ROW -> lv.FLEX_FLOW.ROW
+
+        const withoutPrefix = constant.substring(3); // Remove "LV_"
+
+        // Known enum mappings for LVGL 9.x
+        const enumMappings: { [key: string]: string } = {
+            "ALIGN_": "ALIGN.",
+            "STATE_": "STATE.",
+            "PART_": "PART.",
+            "OPA_": "OPA.",
+            "FLEX_FLOW_": "FLEX_FLOW.",
+            "FLEX_ALIGN_": "FLEX_ALIGN.",
+            "GRID_ALIGN_": "GRID_ALIGN.",
+            "DIR_": "DIR.",
+            "BASE_DIR_": "BASE_DIR.",
+            "TEXT_ALIGN_": "TEXT_ALIGN.",
+            "BORDER_SIDE_": "BORDER_SIDE.",
+            "GRAD_DIR_": "GRAD_DIR.",
+            "SCROLLBAR_MODE_": "SCROLLBAR_MODE.",
+            "SCROLL_SNAP_": "SCROLL_SNAP.",
+            "ANIM_": "ANIM.",
+            "BLEND_MODE_": "BLEND_MODE.",
+            "SCR_LOAD_ANIM_": "SCR_LOAD_ANIM.",
+            "EVENT_": "EVENT.",
+            "KEY_": "KEY.",
+            "LABEL_LONG_": "LABEL_LONG.",
+            "ARC_MODE_": "ARC_MODE.",
+            "BAR_MODE_": "BAR_MODE.",
+            "BTNMATRIX_CTRL_": "BUTTONMATRIX_CTRL.",
+            "CHART_TYPE_": "CHART_TYPE.",
+            "CHART_UPDATE_MODE_": "CHART_UPDATE_MODE.",
+            "CHART_AXIS_": "CHART_AXIS.",
+            "COLORWHEEL_MODE_": "COLORWHEEL_MODE.",
+            "IMG_SIZE_MODE_": "IMAGE_SIZE_MODE.",
+            "KEYBOARD_MODE_": "KEYBOARD_MODE.",
+            "MENU_HEADER_": "MENU_HEADER.",
+            "ROLLER_MODE_": "ROLLER_MODE.",
+            "SLIDER_MODE_": "SLIDER_MODE.",
+            "SPAN_MODE_": "SPAN_MODE.",
+            "SPAN_OVERFLOW_": "SPAN_OVERFLOW.",
+            "TABLE_CELL_CTRL_": "TABLE_CELL_CTRL.",
+            "TEXTAREA_": "TEXTAREA.",
+        };
+
+        for (const [prefix, replacement] of Object.entries(enumMappings)) {
+            if (withoutPrefix.startsWith(prefix)) {
+                const value = withoutPrefix.substring(prefix.length);
+                return `lv.${replacement}${value}`;
+            }
+        }
+
+        // Fallback: convert underscore-separated to dot notation
+        // LV_SOMETHING_VALUE -> lv.SOMETHING.VALUE
+        const parts = withoutPrefix.split("_");
+        if (parts.length >= 2) {
+            const enumName = parts[0];
+            const enumValue = parts.slice(1).join("_");
+            return `lv.${enumName}.${enumValue}`;
+        }
+
+        return `lv.${withoutPrefix}`;
+    }
+
+    stringProperty(
+        type: string,
+        value: string,
+        previewValue?: string,
+        nonEmpty?: boolean
+    ) {
+        if (type == "literal") {
+            return this.stringLiteral(value);
+        }
+
+        if (type == "translated-literal") {
+            // Translation function - can be customized
+            return `_(${this.stringLiteral(value)})`;
+        }
+
+        return nonEmpty ? `" "` : `""`;
+    }
+
+    stringLiteral(str: string) {
+        // Escape string for Python
+        return this.escapePythonString(str ?? "");
+    }
+
+    private escapePythonString(str: string): string {
+        const escaped = str
+            .replace(/\\/g, "\\\\")
+            .replace(/"/g, '\\"')
+            .replace(/\n/g, "\\n")
+            .replace(/\r/g, "\\r")
+            .replace(/\t/g, "\\t");
+        return `"${escaped}"`;
+    }
+
+    color(color: string | number) {
+        // lv_color_hex(0xFF0000) -> lv.color_hex(0xFF0000)
+        if (typeof color === "number") {
+            return `lv.color_hex(0x${color.toString(16).padStart(6, "0").toUpperCase()})`;
+        }
+        return `lv.color_hex(${color})`;
+    }
+
+    image(image: string) {
+        const bitmap = findBitmap(ProjectEditor.getProject(this.widget), image);
+
+        if (bitmap && bitmap.image) {
+            // Reference to image variable
+            return `img_${this.build.getBitmapName(bitmap)}`;
+        }
+        return "None";
+    }
+
+    or(...args: any) {
+        return args.join(" | ");
+    }
+
+    //--------------------------------------------------------------------------
+    // Object accessors
+    //--------------------------------------------------------------------------
+
+    get objectAccessor() {
+        return this.build.getLvglObjectAccessor(this.widget);
+    }
+
+    //--------------------------------------------------------------------------
+    // Object creation - LVGL 9.x MicroPython syntax
+    //--------------------------------------------------------------------------
+
+    createScreen() {
+        this.build.line(`obj = lv.obj(None)`);
+
+        this.build.buildWidgetAssign(this.widget);
+        this.build.buildWidgetSetPosAndSize(this.widget);
+
+        return "obj";
+    }
+
+    createObject(createObjectFunction: string, ...args: any[]) {
+        // lv_btn_create(parent) -> lv.button(parent)
+        // lv_label_create(parent) -> lv.label(parent)
+        const pythonClass = this.convertCreateFunction(createObjectFunction);
+
+        const allArgs = ["parent_obj", ...args].join(", ");
+        this.build.line(`obj = ${pythonClass}(${allArgs})`);
+
+        this.build.buildWidgetAssign(this.widget);
+        this.build.buildWidgetSetPosAndSize(this.widget);
+
+        return "obj";
+    }
+
+    private convertCreateFunction(func: string): string {
+        // lv_xxx_create -> lv.xxx
+        // Special mappings for LVGL 9.x naming changes
+        const mappings: { [key: string]: string } = {
+            "lv_obj_create": "lv.obj",
+            "lv_btn_create": "lv.button",
+            "lv_label_create": "lv.label",
+            "lv_img_create": "lv.image",
+            "lv_arc_create": "lv.arc",
+            "lv_bar_create": "lv.bar",
+            "lv_slider_create": "lv.slider",
+            "lv_switch_create": "lv.switch",
+            "lv_checkbox_create": "lv.checkbox",
+            "lv_dropdown_create": "lv.dropdown",
+            "lv_roller_create": "lv.roller",
+            "lv_textarea_create": "lv.textarea",
+            "lv_table_create": "lv.table",
+            "lv_chart_create": "lv.chart",
+            "lv_canvas_create": "lv.canvas",
+            "lv_calendar_create": "lv.calendar",
+            "lv_keyboard_create": "lv.keyboard",
+            "lv_list_create": "lv.list",
+            "lv_menu_create": "lv.menu",
+            "lv_msgbox_create": "lv.msgbox",
+            "lv_spinner_create": "lv.spinner",
+            "lv_spinbox_create": "lv.spinbox",
+            "lv_tabview_create": "lv.tabview",
+            "lv_tileview_create": "lv.tileview",
+            "lv_win_create": "lv.win",
+            "lv_colorwheel_create": "lv.colorwheel",
+            "lv_led_create": "lv.led",
+            "lv_meter_create": "lv.meter",
+            "lv_span_create": "lv.span",
+            "lv_spangroup_create": "lv.spangroup",
+            "lv_btnmatrix_create": "lv.buttonmatrix",
+            "lv_line_create": "lv.line",
+            "lv_scale_create": "lv.scale",
+            "lv_imagebutton_create": "lv.imagebutton",
+            "lv_animimg_create": "lv.animimg",
+        };
+
+        if (mappings[func]) {
+            return mappings[func];
+        }
+
+        // Generic conversion: lv_xxx_create -> lv.xxx
+        const match = func.match(/^lv_(\w+)_create$/);
+        if (match) {
+            return `lv.${match[1]}`;
+        }
+
+        return func;
+    }
+
+    getObject(getObjectFunction: string, ...args: any[]) {
+        const pythonFunc = this.convertGetFunction(getObjectFunction);
+
+        this.build.line(
+            `obj = ${pythonFunc}(${["parent_obj", ...args].join(", ")})`
+        );
+
+        this.build.buildWidgetAssign(this.widget);
+
+        return "obj";
+    }
+
+    getParentObject(getObjectFunction: string, ...args: any[]) {
+        const pythonFunc = this.convertGetFunction(getObjectFunction);
+
+        this.build.line(
+            `obj = ${pythonFunc}(${[
+                "parent_obj.get_parent()",
+                ...args
+            ].join(", ")})`
+        );
+
+        this.build.buildWidgetAssign(this.widget);
+
+        return "obj";
+    }
+
+    private convertGetFunction(func: string): string {
+        // lv_xxx_get_yyy -> xxx.get_yyy or direct conversion
+        // Most get functions in MicroPython are methods
+        return func.replace(/^lv_/, "lv.");
+    }
+
+    //--------------------------------------------------------------------------
+    // Function calls
+    //--------------------------------------------------------------------------
+
+    callObjectFunction(func: string, ...args: any[]): any {
+        // lv_obj_set_pos(obj, x, y) -> obj.set_pos(x, y)
+        const methodName = this.convertToMethod(func);
+        const objRef = this.isTick ? this.objectAccessor : "obj";
+
+        this.build.line(`${objRef}.${methodName}(${args.join(", ")})`);
+        return undefined;
+    }
+
+    callObjectFunctionWithAssignment(
+        declType: string,
+        declName: string,
+        func: string,
+        ...args: any[]
+    ): any {
+        const methodName = this.convertToMethod(func);
+        const objRef = this.isTick ? this.objectAccessor : "obj";
+
+        this.build.line(`${declName} = ${objRef}.${methodName}(${args.join(", ")})`);
+        return declName;
+    }
+
+    callObjectFunctionInline(func: string, ...args: any[]): any {
+        const methodName = this.convertToMethod(func);
+        const objRef = this.isTick ? this.objectAccessor : "obj";
+
+        return `${objRef}.${methodName}(${args.join(", ")})`;
+    }
+
+    private convertToMethod(func: string): string {
+        // lv_obj_set_pos -> set_pos
+        // lv_obj_get_width -> get_width
+        // lv_label_set_text -> set_text
+
+        // Remove lv_ prefix and object type prefix
+        const withoutLv = func.replace(/^lv_/, "");
+
+        // Common patterns to remove
+        const prefixesToRemove = [
+            "obj_", "label_", "btn_", "img_", "arc_", "bar_", "slider_",
+            "switch_", "checkbox_", "dropdown_", "roller_", "textarea_",
+            "table_", "chart_", "canvas_", "calendar_", "keyboard_",
+            "list_", "menu_", "msgbox_", "spinner_", "spinbox_",
+            "tabview_", "tileview_", "win_", "colorwheel_", "led_",
+            "meter_", "span_", "spangroup_", "btnmatrix_", "line_",
+            "scale_", "imagebutton_", "animimg_", "style_", "image_",
+            "button_", "buttonmatrix_"
+        ];
+
+        for (const prefix of prefixesToRemove) {
+            if (withoutLv.startsWith(prefix)) {
+                return withoutLv.substring(prefix.length);
+            }
+        }
+
+        return withoutLv;
+    }
+
+    callFreeFunction(func: string, ...args: any[]): any {
+        // lv_xxx_yyy() -> lv.xxx_yyy() or special handling
+        const pythonFunc = this.convertFreeFunction(func);
+        this.build.line(`${pythonFunc}(${args.join(", ")})`);
+        return undefined;
+    }
+
+    callFreeFunctionWithAssignment(
+        declType: string,
+        declName: string,
+        func: string,
+        ...args: any[]
+    ): any {
+        const pythonFunc = this.convertFreeFunction(func);
+        this.build.line(`${declName} = ${pythonFunc}(${args.join(", ")})`);
+        return declName;
+    }
+
+    private convertFreeFunction(func: string): string {
+        // lv_scr_load -> lv.screen_load
+        // lv_disp_get_default -> lv.display.get_default
+        const mappings: { [key: string]: string } = {
+            "lv_scr_load": "lv.screen_load",
+            "lv_scr_load_anim": "lv.screen_load_anim",
+            "lv_scr_act": "lv.screen_active",
+            "lv_layer_top": "lv.layer_top",
+            "lv_layer_sys": "lv.layer_sys",
+            "lv_disp_get_default": "lv.display.get_default",
+            "lv_theme_default_init": "lv.theme_default_init",
+            "lv_color_hex": "lv.color_hex",
+            "lv_color_make": "lv.color_make",
+            "lv_color_white": "lv.color_white",
+            "lv_color_black": "lv.color_black",
+            "lv_pct": "lv.pct",
+            "lv_anim_init": "lv.anim_t",
+            "strcmp": "# strcmp - use Python comparison",
+            "strncmp": "# strncmp - use Python comparison",
+        };
+
+        if (mappings[func]) {
+            return mappings[func];
+        }
+
+        // Generic: lv_xxx -> lv.xxx
+        return func.replace(/^lv_/, "lv.");
+    }
+
+    //--------------------------------------------------------------------------
+    // Property evaluation (simplified for non-flow MicroPython)
+    //--------------------------------------------------------------------------
+
+    evalTextProperty(
+        declType: string,
+        declName: string,
+        propertyValue: string,
+        errorMessage: any
+    ) {
+        // For MicroPython without flow, return variable directly
+        this.build.line(`${declName} = get_var_${this.toSnakeCase(propertyValue)}()`);
+        return declName;
+    }
+
+    evalIntegerProperty(
+        declType: string,
+        declName: string,
+        propertyValue: string,
+        errorMessage: any
+    ) {
+        this.build.line(`${declName} = get_var_${this.toSnakeCase(propertyValue)}()`);
+        return declName;
+    }
+
+    evalUnsignedIntegerProperty(
+        declType: string,
+        declName: string,
+        propertyValue: string,
+        errorMessage: any
+    ) {
+        this.build.line(`${declName} = get_var_${this.toSnakeCase(propertyValue)}()`);
+        return declName;
+    }
+
+    evalStringArrayPropertyAndJoin(
+        declType: string,
+        declName: string,
+        propertyValue: string,
+        errorMessage: any
+    ) {
+        this.build.line(`${declName} = "\\n".join(get_var_${this.toSnakeCase(propertyValue)}())`);
+        return declName;
+    }
+
+    private toSnakeCase(str: string): string {
+        return str
+            .replace(/([A-Z])/g, "_$1")
+            .toLowerCase()
+            .replace(/^_/, "");
+    }
+
+    assignIntegerProperty(
+        propertyName: string,
+        propertyValue: string,
+        value: any,
+        errorMessage: any
+    ): void {
+        this.build.line(`set_var_${this.toSnakeCase(propertyValue)}(${value})`);
+    }
+
+    assignStringProperty(
+        propertyName: string,
+        propertyValue: string,
+        value: any,
+        errorMessage: any
+    ): void {
+        this.build.line(`set_var_${this.toSnakeCase(propertyValue)}(${value})`);
+    }
+
+    //--------------------------------------------------------------------------
+    // Tick callbacks
+    //--------------------------------------------------------------------------
+
+    addToTick(propertyName: string, callback: () => void) {
+        const widget = this.widget;
+
+        this.build.addTickCallback(() => {
+            this.widget = widget;
+            this.isTick = true;
+            callback();
+            this.isTick = false;
+        });
+    }
+
+    tickChangeStart() {
+        this.build.line(`tick_value_change_obj = ${this.objectAccessor}`);
+    }
+
+    tickChangeEnd() {
+        this.build.line(`tick_value_change_obj = None`);
+    }
+
+    //--------------------------------------------------------------------------
+    // Control flow
+    //--------------------------------------------------------------------------
+
+    assign(declType: string, declName: string, rhs: any) {
+        // Python doesn't need type declarations
+        this.build.line(`${declName} = ${rhs}`);
+        return declName;
+    }
+
+    if(a: any, callback: () => void) {
+        this.build.blockStart(`if ${a}:`);
+        callback();
+        this.build.blockEnd("");
+    }
+
+    ifStringNotEqual(a: any, b: any, callback: () => void) {
+        this.build.blockStart(`if ${a} != ${b}:`);
+        callback();
+        this.build.blockEnd("");
+    }
+
+    ifStringNotEqualN(a: any, b: any, n: any, callback: () => void) {
+        this.build.blockStart(`if ${a}[:${n}] != ${b}[:${n}]:`);
+        callback();
+        this.build.blockEnd("");
+    }
+
+    ifIntegerLess(a: any, b: any, callback: () => void) {
+        this.build.blockStart(`if ${a} < ${b}:`);
+        callback();
+        this.build.blockEnd("");
+    }
+
+    ifIntegerNotEqual(a: any, b: any, callback: () => void) {
+        this.build.blockStart(`if ${a} != ${b}:`);
+        callback();
+        this.build.blockEnd("");
+    }
+
+    //--------------------------------------------------------------------------
+    // Color handling
+    //--------------------------------------------------------------------------
+
+    buildColor<T>(
+        object: IEezObject,
+        color: string,
+        getParams: () => T,
+        callback: (color: string, params: T) => void,
+        updateCallback: (color: any, params: T) => void
+    ) {
+        this.build.buildColor(
+            object,
+            color,
+            getParams,
+            callback,
+            updateCallback
+        );
+    }
+
+    buildColor2<T>(
+        object: IEezObject,
+        color1: string,
+        color2: string,
+        getParams: () => T,
+        callback: (color1: string, color2: string, params: T) => void,
+        updateCallback: (color1: any, color2: any, params: T) => void
+    ) {
+        this.build.buildColor2(
+            object,
+            color1,
+            color2,
+            getParams,
+            callback,
+            updateCallback
+        );
+    }
+
+    genFileStaticVar(id: string, type: string, prefixName: string) {
+        return this.build.genFileStaticVar(id, type, prefixName);
+    }
+
+    assingToFileStaticVar(varName: string, value: string) {
+        this.build.assingToFileStaticVar(varName, value);
+    }
+
+    //--------------------------------------------------------------------------
+    // Block structure (Python uses indentation)
+    //--------------------------------------------------------------------------
+
+    blockStart(param: any) {
+        this.build.blockStart(param);
+    }
+
+    blockEnd(param: any) {
+        this.build.blockEnd(param);
+    }
+
+    //--------------------------------------------------------------------------
+    // Event handlers
+    //--------------------------------------------------------------------------
+
+    addEventHandler(
+        eventName: string,
+        callback: (event: any, tick_value_change_obj: any) => void
+    ) {
+        const widget = this.widget;
+        const componentIndex = this.componentIndex;
+        const propertyIndex = this.propertyIndex;
+
+        this.build.addEventHandler(this.widget, () => {
+            this.build.blockStart(`if event == lv.EVENT.${eventName}:`);
+
+            this.widget = widget;
+            this.componentIndex = componentIndex;
+            this.propertyIndex = propertyIndex;
+
+            callback("e", "tick_value_change_obj");
+
+            this.build.blockEnd("");
+        });
+    }
+
+    lvglAddObjectFlowCallback(propertyName: string, filter: number) {
+        // Flow callbacks not supported in MicroPython mode
+    }
+
+    postPageExecute(callback: () => void) {
+        this.build.postBuildAdd(callback);
+    }
+
+    postWidgetExecute(callback: () => void) {
+        this.noGoodNameCallbacks.push(callback);
+    }
+}

--- a/packages/project-editor/project/project.tsx
+++ b/packages/project-editor/project/project.tsx
@@ -275,6 +275,7 @@ export class Build extends EezObject {
     lvglInclude: string;
     screensLifetimeSupport: boolean;
     generateSourceCodeForEezFramework: boolean;
+    generateMicroPython: boolean;
     compressFlowDefinition: boolean;
     executionQueueSize: number;
     expressionEvaluatorStackSize: number;
@@ -375,6 +376,16 @@ export class Build extends EezObject {
                     !getProject(object).projectTypeTraits.hasFlowSupport
             },
             {
+                name: "generateMicroPython",
+                displayName:
+                    "Generate MicroPython code (LVGL 9.x bindings)",
+                type: PropertyType.Boolean,
+                checkboxStyleSwitch: true,
+                disabled: object =>
+                    isNotLVGLProject(object) ||
+                    getProject(object).settings.general.lvglVersion != "9.0"
+            },
+            {
                 name: "compressFlowDefinition",
                 type: PropertyType.Boolean,
                 checkboxStyleSwitch: true,
@@ -408,6 +419,10 @@ export class Build extends EezObject {
 
             if (jsObject.generateSourceCodeForEezFramework == undefined) {
                 jsObject.generateSourceCodeForEezFramework = false;
+            }
+
+            if (jsObject.generateMicroPython == undefined) {
+                jsObject.generateMicroPython = false;
             }
 
             if (jsObject.compressFlowDefinition == undefined) {
@@ -481,6 +496,7 @@ export class Build extends EezObject {
             lvglInclude: observable,
             screensLifetimeSupport: observable,
             generateSourceCodeForEezFramework: observable,
+            generateMicroPython: observable,
             compressFlowDefinition: observable,
             executionQueueSize: observable,
             expressionEvaluatorStackSize: observable


### PR DESCRIPTION
This commit introduces the ability to generate MicroPython code with LVGL 9.x bindings as an alternative output format alongside the existing C code generation.

New features:
- MicroPythonLVGLCode class implementing LVGLCode interface for Python output
- MicroPythonLVGLBuild class for orchestrating the MicroPython generation
- New build option "Generate MicroPython code (LVGL 9.x bindings)"
- Automatic C-to-Python API translation for lv_micropython bindings

Key API mappings:
- lv_btn_create(parent) -> lv.button(parent)
- lv_obj_set_pos(obj, x, y) -> obj.set_pos(x, y)
- LV_ALIGN_CENTER -> lv.ALIGN.CENTER
- lv_color_hex(0xFF0000) -> lv.color_hex(0xFF0000)

The generated Python file (_ui.py) can be used with MicroPython devices that have LVGL support enabled.