### PR TITLE
fix(lvgl-versions): read .bin files as Buffer to avoid corruption in LVGL 9.0 image export

### DIFF
--- a/packages/project-editor/lvgl/lvgl-versions.ts
+++ b/packages/project-editor/lvgl/lvgl-versions.ts
@@ -303,7 +303,7 @@ const versions = {
                 await fs.promises.writeFile(bitmapFilePath, bin);
             }
 
-            return new Promise<string>((resolve, reject) => {
+            return new Promise<string | Buffer>((resolve, reject) => {
                 const { PythonShell } =
                     require("python-shell") as typeof import("python-shell");
 
@@ -357,7 +357,7 @@ const versions = {
                                 `${tempDir}/${fileName}.${
                                     binFile ? "bin" : "c"
                                 }`,
-                                binFile ? "binary" : "utf-8"
+                                binFile ? null : "utf-8"
                             );
 
                             resolve(cFile);


### PR DESCRIPTION
Binary image export used fs.promises.readFile with 'utf-8' encoding, causing data corruption when reading .bin files as strings. Updated return type to Promise<string | Buffer> and switched to null encoding when binFile is true so Node returns a Buffer. Binary exports now match manual output byte-for-byte with LVGLImage.py.

Because of this bug, for example, it was impossible to use LittleFS and automatically generated images. After the patch, the images display correctly.