### PR TITLE
fix formatting of LVGL version section in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,8 +27,7 @@ If applicable, add screenshots to help explain your problem.
  - OS: [e.g. Windows]
  - Version [e.g. 10]
 
-** LVGL version (if used)**
-
+**LVGL version (if used)**
 - 8.x or 9.x
 
 **Additional context**


### PR DESCRIPTION
- remove space in heading to enable bold font
- remove new line after heading