### PR TITLE
Enable label widget recolor for LVGL 9.3+

### DIFF
--- a/packages/project-editor/lvgl/widgets/Label.tsx
+++ b/packages/project-editor/lvgl/widgets/Label.tsx
@@ -160,7 +160,7 @@ export class LVGLLabelWidget extends LVGLWidget {
         }
 
         // recolor
-        if (this.recolor && !code.isV9) {
+        if (this.recolor && !code.isLVGLVersion(["9.0", "9.1", "9.2"])) {
             code.callObjectFunction(
                 "lv_label_set_recolor",
                 code.constant("true")


### PR DESCRIPTION
The recolor option for the label widget was removed in LVGL 9.0 but added back again in 9.3
Fixes issue #777 