### PR TITLE
Fixed a bug in preview window when using grid and spans in V8 LVGL

### DIFF
--- a/packages/project-editor/lvgl/style-catalog.tsx
+++ b/packages/project-editor/lvgl/style-catalog.tsx
@@ -854,7 +854,11 @@ const grid_cell_column_span_property_info: LVGLPropertyInfo = {
         defaultValue: "1",
         inherited: false,
         layout: true,
-        extDraw: false
+        extDraw: false,
+        valueToNum: (value: string, projectStore) =>
+            projectStore.project.settings.general.lvglVersion.startsWith("8.")
+                ? parseInt(value) * 2 // For some reason, in v8.x, the value must be multiplied by 2, but, only in simulator
+                : parseInt(value)
     }
 };
 
@@ -910,7 +914,11 @@ const grid_cell_row_span_property_info: LVGLPropertyInfo = {
         defaultValue: "1",
         inherited: false,
         layout: true,
-        extDraw: false
+        extDraw: false,
+        valueToNum: (value: string, projectStore) =>
+            projectStore.project.settings.general.lvglVersion.startsWith("8.")
+                ? parseInt(value) * 2 // For some reason, in v8.x, the value must be multiplied by 2, but, only in simulator
+                : parseInt(value)
     }
 };
 
@@ -1497,31 +1505,31 @@ const BorderSide = observer(
 
                                 ...(settingsController.isDarkTheme
                                     ? {
-                                          neutral0: "hsl(0, 0%, 10%)",
-                                          neutral5: "hsl(0, 0%, 20%)",
-                                          neutral10: "hsl(0, 0%, 30%)",
-                                          neutral20: "hsl(0, 0%, 40%)",
-                                          neutral30: "hsl(0, 0%, 50%)",
-                                          neutral40: "hsl(0, 0%, 60%)",
-                                          neutral50: "hsl(0, 0%, 70%)",
-                                          neutral60: "hsl(0, 0%, 80%)",
-                                          neutral70: "hsl(0, 0%, 90%)",
-                                          neutral80: "hsl(0, 0%, 95%)",
-                                          neutral90: "hsl(0, 0%, 100%)"
-                                      }
+                                        neutral0: "hsl(0, 0%, 10%)",
+                                        neutral5: "hsl(0, 0%, 20%)",
+                                        neutral10: "hsl(0, 0%, 30%)",
+                                        neutral20: "hsl(0, 0%, 40%)",
+                                        neutral30: "hsl(0, 0%, 50%)",
+                                        neutral40: "hsl(0, 0%, 60%)",
+                                        neutral50: "hsl(0, 0%, 70%)",
+                                        neutral60: "hsl(0, 0%, 80%)",
+                                        neutral70: "hsl(0, 0%, 90%)",
+                                        neutral80: "hsl(0, 0%, 95%)",
+                                        neutral90: "hsl(0, 0%, 100%)"
+                                    }
                                     : {
-                                          neutral0: "hsl(0, 0%, 100%)",
-                                          neutral5: "hsl(0, 0%, 95%)",
-                                          neutral10: "hsl(0, 0%, 90%)",
-                                          neutral20: "hsl(0, 0%, 80%)",
-                                          neutral30: "hsl(0, 0%, 70%)",
-                                          neutral40: "hsl(0, 0%, 60%)",
-                                          neutral50: "hsl(0, 0%, 50%)",
-                                          neutral60: "hsl(0, 0%, 40%)",
-                                          neutral70: "hsl(0, 0%, 30%)",
-                                          neutral80: "hsl(0, 0%, 20%)",
-                                          neutral90: "hsl(0, 0%, 10%)"
-                                      }),
+                                        neutral0: "hsl(0, 0%, 100%)",
+                                        neutral5: "hsl(0, 0%, 95%)",
+                                        neutral10: "hsl(0, 0%, 90%)",
+                                        neutral20: "hsl(0, 0%, 80%)",
+                                        neutral30: "hsl(0, 0%, 70%)",
+                                        neutral40: "hsl(0, 0%, 60%)",
+                                        neutral50: "hsl(0, 0%, 50%)",
+                                        neutral60: "hsl(0, 0%, 40%)",
+                                        neutral70: "hsl(0, 0%, 30%)",
+                                        neutral80: "hsl(0, 0%, 20%)",
+                                        neutral90: "hsl(0, 0%, 10%)"
+                                    }),
 
                                 primary: "#2684FF",
                                 primary25: "#DEEBFF",
@@ -1534,7 +1542,7 @@ const BorderSide = observer(
                         option: (baseStyles, state) => ({
                             ...baseStyles,
                             ...(settingsController.isDarkTheme &&
-                            state.isFocused
+                                state.isFocused
                                 ? { color: "#333" }
                                 : {})
                         })
@@ -2240,31 +2248,31 @@ const TextDecorationSide = observer(
 
                                 ...(settingsController.isDarkTheme
                                     ? {
-                                          neutral0: "hsl(0, 0%, 10%)",
-                                          neutral5: "hsl(0, 0%, 20%)",
-                                          neutral10: "hsl(0, 0%, 30%)",
-                                          neutral20: "hsl(0, 0%, 40%)",
-                                          neutral30: "hsl(0, 0%, 50%)",
-                                          neutral40: "hsl(0, 0%, 60%)",
-                                          neutral50: "hsl(0, 0%, 70%)",
-                                          neutral60: "hsl(0, 0%, 80%)",
-                                          neutral70: "hsl(0, 0%, 90%)",
-                                          neutral80: "hsl(0, 0%, 95%)",
-                                          neutral90: "hsl(0, 0%, 100%)"
-                                      }
+                                        neutral0: "hsl(0, 0%, 10%)",
+                                        neutral5: "hsl(0, 0%, 20%)",
+                                        neutral10: "hsl(0, 0%, 30%)",
+                                        neutral20: "hsl(0, 0%, 40%)",
+                                        neutral30: "hsl(0, 0%, 50%)",
+                                        neutral40: "hsl(0, 0%, 60%)",
+                                        neutral50: "hsl(0, 0%, 70%)",
+                                        neutral60: "hsl(0, 0%, 80%)",
+                                        neutral70: "hsl(0, 0%, 90%)",
+                                        neutral80: "hsl(0, 0%, 95%)",
+                                        neutral90: "hsl(0, 0%, 100%)"
+                                    }
                                     : {
-                                          neutral0: "hsl(0, 0%, 100%)",
-                                          neutral5: "hsl(0, 0%, 95%)",
-                                          neutral10: "hsl(0, 0%, 90%)",
-                                          neutral20: "hsl(0, 0%, 80%)",
-                                          neutral30: "hsl(0, 0%, 70%)",
-                                          neutral40: "hsl(0, 0%, 60%)",
-                                          neutral50: "hsl(0, 0%, 50%)",
-                                          neutral60: "hsl(0, 0%, 40%)",
-                                          neutral70: "hsl(0, 0%, 30%)",
-                                          neutral80: "hsl(0, 0%, 20%)",
-                                          neutral90: "hsl(0, 0%, 10%)"
-                                      }),
+                                        neutral0: "hsl(0, 0%, 100%)",
+                                        neutral5: "hsl(0, 0%, 95%)",
+                                        neutral10: "hsl(0, 0%, 90%)",
+                                        neutral20: "hsl(0, 0%, 80%)",
+                                        neutral30: "hsl(0, 0%, 70%)",
+                                        neutral40: "hsl(0, 0%, 60%)",
+                                        neutral50: "hsl(0, 0%, 50%)",
+                                        neutral60: "hsl(0, 0%, 40%)",
+                                        neutral70: "hsl(0, 0%, 30%)",
+                                        neutral80: "hsl(0, 0%, 20%)",
+                                        neutral90: "hsl(0, 0%, 10%)"
+                                    }),
 
                                 primary: "#2684FF",
                                 primary25: "#DEEBFF",
@@ -2277,7 +2285,7 @@ const TextDecorationSide = observer(
                         option: (baseStyles, state) => ({
                             ...baseStyles,
                             ...(settingsController.isDarkTheme &&
-                            state.isFocused
+                                state.isFocused
                                 ? { color: "#333" }
                                 : {})
                         })


### PR DESCRIPTION
The program preview suffers of a bug when previewing a grid layout with row spans or column spans. The final program and the compiled preview (Full Simulation) shows the correct position while the preview requires a 2x of the value.

### Example

In the example I have used a simple container with a border to be able to determine their position and size and a panel inside that container.

The widget customizations are:

- Container
  - Layout
    - Layout: GRID
    - Grid row descriptor: 16 FR(1) 16
    - Grid column descriptor: FR(1) FR(1) FR(1) FR(1)
- Panel
  - Layout
    - Grid cell column pos: 0
    - Grid cell column span: 4
    - Grid cell X align: CENTER
    - Grid cell row pos: 1
    - Grid cell row span: 1
    - Grid cell Y align: CENTER

Original version:

<img width="804" height="481" alt="Captura de pantalla_20260531_162427" src="https://github.com/user-attachments/assets/448816f3-6806-49ed-bcd5-46fd6c2ec13b" />

The widget is only expanded by 2 of the 4 columns. 

Fixed version:

<img width="801" height="479" alt="Captura de pantalla_20260531_162750" src="https://github.com/user-attachments/assets/535490c7-c066-471e-a637-4e82c4b532bd" />

The widget is expanded across the 4 columns and then centered.

The same applies to the row span.