### PR TITLE
Fix LVGL widget copy/paste serialization

### DIFF
--- a/packages/project-editor/flow/component.tsx
+++ b/packages/project-editor/flow/component.tsx
@@ -2956,7 +2956,11 @@ export class Widget extends Component {
                     return widgetEvents;
                 }
 
-                if (jsObject.action) {
+                const hasLegacyAction = Object.prototype.hasOwnProperty.call(
+                    jsObject,
+                    "action"
+                );
+                if (hasLegacyAction && jsObject.action) {
                     const widgetEvents = getWidgetEvents();
                     if (widgetEvents) {
                         for (const eventName of Object.keys(widgetEvents)) {


### PR DESCRIPTION
Fixes LVGL widget copy/paste from the Widgets Structure panel.

The legacy action migration in Widget.beforeLoadHook was reading jsObject.action directly. During copy serialization, jsObject can still expose the Widget.action getter through the prototype, which triggers LVGL event lookup before the cloned object is attached to a Project root. That causes Project settings lookup to fail and prevents clipboard data from being written.

This change only migrates the legacy action field when it is an own property of the serialized object.

Verified:
- LVGL widget Copy/Paste via context menu
- LVGL widget Ctrl+C / Ctrl+V
- npm run build