### PR TITLE
WIP: extension interface — initExtension(api) executed in main and renderer processes

### DIFF
--- a/packages/eez-studio-shared/extensions/extension.ts
+++ b/packages/eez-studio-shared/extensions/extension.ts
@@ -175,20 +175,16 @@ export interface IExtensionDefinition {
     preInstalled: boolean;
     extensionType: ExtensionType;
 
-    init?: () => void;
-    destroy?: () => void;
-
     /**
-     * Process-aware initialization: the extension receives an API object from
-     * Studio. Extensions are loaded in both the main process (main/setup.ts)
-     * and the renderer process (home/main.tsx); `api.fromProcess` tells which
-     * one is initializing. Use this instead of `init` when the extension
-     * needs to hook both processes (e.g. start a local server in main,
-     * register IPC handlers in renderer). When defined, it replaces `init`.
-     * The API surface is expected to grow (ipc helpers, handler registration
-     * etc.) — see issue #1042.
+     * Called when the extension is registered, in both the main process
+     * (main/setup.ts) and the renderer process (home/main.tsx). Extensions
+     * that need to hook both processes can read `api.fromProcess` to tell
+     * which one is initializing (e.g. start a local server in main, register
+     * IPC handlers in renderer). Extensions that don't use the parameter are
+     * unaffected. The API surface is expected to grow — see issue #1042.
      */
-    initExtension?: (api: IExtensionApi) => void;
+    init?: (api: IExtensionApi) => void;
+    destroy?: () => void;
 
     loadExtension?: (
         extensionFolderPath: string

--- a/packages/eez-studio-shared/extensions/extension.ts
+++ b/packages/eez-studio-shared/extensions/extension.ts
@@ -167,6 +167,16 @@ export interface IExtensionDefinition {
     init?: () => void;
     destroy?: () => void;
 
+    /**
+     * Process-aware initialization. Extensions are loaded in both the main
+     * process (main/setup.ts) and the renderer process (home/main.tsx);
+     * `fromProcess` tells which one is initializing. Use this instead of
+     * `init` when the extension needs to hook both processes (e.g. start a
+     * local server in main, register IPC handlers in renderer). When defined,
+     * it replaces `init`.
+     */
+    initExtension?: (params: { fromProcess: "main" | "renderer" }) => void;
+
     loadExtension?: (
         extensionFolderPath: string
     ) => Promise<IExtension | undefined>;

--- a/packages/eez-studio-shared/extensions/extension.ts
+++ b/packages/eez-studio-shared/extensions/extension.ts
@@ -154,6 +154,17 @@ export interface IExtensionHost {
     activeTab: IHomeTab;
 }
 
+/**
+ * API object passed to IExtensionDefinition.initExtension.
+ */
+export interface IExtensionApi {
+    /**
+     * Which process is initializing the extension: "main" (main/setup.ts) or
+     * "renderer" (home/main.tsx).
+     */
+    fromProcess: "main" | "renderer";
+}
+
 export type ExtensionType =
     | "built-in"
     | "iext"
@@ -168,14 +179,16 @@ export interface IExtensionDefinition {
     destroy?: () => void;
 
     /**
-     * Process-aware initialization. Extensions are loaded in both the main
-     * process (main/setup.ts) and the renderer process (home/main.tsx);
-     * `fromProcess` tells which one is initializing. Use this instead of
-     * `init` when the extension needs to hook both processes (e.g. start a
-     * local server in main, register IPC handlers in renderer). When defined,
-     * it replaces `init`.
+     * Process-aware initialization: the extension receives an API object from
+     * Studio. Extensions are loaded in both the main process (main/setup.ts)
+     * and the renderer process (home/main.tsx); `api.fromProcess` tells which
+     * one is initializing. Use this instead of `init` when the extension
+     * needs to hook both processes (e.g. start a local server in main,
+     * register IPC handlers in renderer). When defined, it replaces `init`.
+     * The API surface is expected to grow (ipc helpers, handler registration
+     * etc.) — see issue #1042.
      */
-    initExtension?: (params: { fromProcess: "main" | "renderer" }) => void;
+    initExtension?: (api: IExtensionApi) => void;
 
     loadExtension?: (
         extensionFolderPath: string

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -138,10 +138,8 @@ export function setExtensionsFromProcess(value: FromProcess) {
 }
 
 export function registerExtension(extension: IExtension) {
-    if (extension.initExtension) {
-        extension.initExtension({ fromProcess });
-    } else if (extension.init) {
-        extension.init();
+    if (extension.init) {
+        extension.init({ fromProcess });
     }
 
     action(() => extensions.set(extension.id, extension))();

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -21,7 +21,8 @@ import { registerSource, sendMessage, watch } from "eez-studio-shared/notify";
 import {
     IExtension,
     IExtensionProperties,
-    ExtensionType
+    ExtensionType,
+    IExtensionApi
 } from "eez-studio-shared/extensions/extension";
 
 import {
@@ -124,7 +125,7 @@ async function loadExtension(
     return undefined;
 }
 
-export type FromProcess = "main" | "renderer";
+export type FromProcess = IExtensionApi["fromProcess"];
 
 // Which process is loading extensions. Both the main process (main/setup.ts)
 // and the renderer (home/main.tsx) load the installed extensions;

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -124,8 +124,22 @@ async function loadExtension(
     return undefined;
 }
 
+export type FromProcess = "main" | "renderer";
+
+// Which process is loading extensions. Both the main process (main/setup.ts)
+// and the renderer (home/main.tsx) load the installed extensions;
+// initExtension uses this to tell them apart. Renderer is the default so
+// existing entry points keep their current behavior.
+let fromProcess: FromProcess = "renderer";
+
+export function setExtensionsFromProcess(value: FromProcess) {
+    fromProcess = value;
+}
+
 export function registerExtension(extension: IExtension) {
-    if (extension.init) {
+    if (extension.initExtension) {
+        extension.initExtension({ fromProcess });
+    } else if (extension.init) {
         extension.init();
     }
 

--- a/packages/main/setup.ts
+++ b/packages/main/setup.ts
@@ -1,8 +1,13 @@
 import { getUserDataPath, makeFolder } from "eez-studio-shared/util-electron";
 import { EXTENSIONS_FOLDER_NAME } from "eez-studio-shared/conf";
-import { loadExtensions } from "eez-studio-shared/extensions/extensions";
+import {
+    loadExtensions,
+    setExtensionsFromProcess
+} from "eez-studio-shared/extensions/extensions";
 
 export async function setup() {
+    setExtensionsFromProcess("main");
+
     const extensionsFolderPath = getUserDataPath(EXTENSIONS_FOLDER_NAME);
     await makeFolder(extensionsFolderPath);
 


### PR DESCRIPTION
WIP — opening early per the direction agreed in #1042 so the interface shape can be reviewed before the rest lands. Type-checked, not yet runtime-tested against master.

## Motivation

Follow-up to #1042: we're building an MCP bridge for AI agents as an EEZ Studio **extension** (so tools and skills can update without Studio releases). Such an extension needs code running in **both** processes:

- **main**: start/stop an opt-in localhost HTTP server (external agents POST tool requests)
- **renderer**: execute the tools against Studio internals and answer asynchronously

Extensions are already loaded in both processes (`main/setup.ts` and `home/main.tsx` both call `loadExtensions`), but an extension cannot tell which process is initializing it — and reaching into internals from extension code is exactly what we want to avoid.

## What this PR adds (minimal, opt-in)

- `IExtensionDefinition.initExtension?: (api: IExtensionApi) => void` — process-aware lifecycle hook; **when defined it replaces `init()`**; `init()` and all existing extensions are unaffected
- `IExtensionApi` — the API object Studio passes in. First member:

  ```ts
  export interface IExtensionApi {
      fromProcess: "main" | "renderer";
  }
  ```

  intended to grow (ipc helpers to talk main↔renderer, handler registration, …) shaped by what extensions actually need
- `setExtensionsFromProcess("main")` called from the main-process entry point; renderer stays the default so current behavior is unchanged

Design choice worth flagging: `fromProcess` is module-level state rather than a threaded parameter, so `reloadExtension` / `importExtensionToFolder` paths stay correct without touching their signatures.

## Not in this PR (deliberately)

- The API members beyond `fromProcess` (e.g. `api.ipc`, renderer-side registration) — we'd rather add them one by one against real extension needs, with your guidance on the shape
- The MCP extension itself — it lives in https://github.com/IWILLTBEST/eez-studio-mcp and will consume this interface

Happy to restructure (rename, move, split) in any direction you prefer.
