### PR TITLE
Extension API: explicit Studio exports on IExtensionApi + requireModule for third-party modules

### DIFF
--- a/packages/eez-studio-shared/extensions/extension.ts
+++ b/packages/eez-studio-shared/extensions/extension.ts
@@ -167,40 +167,50 @@ export interface IOpenProjectInfo {
 }
 
 /**
- * API object passed to IExtensionDefinition.initExtension.
+ * API object passed to IExtensionDefinition.init. Only the field matching
+ * the current process is populated — `main` when initializing in the main
+ * process, `renderer` when initializing in the renderer process — so an
+ * extension can tell which process it's running in by checking which of
+ * the two is present.
  */
 export interface IExtensionApi {
-    /**
-     * Which process is initializing the extension: "main" (main/setup.ts) or
-     * "renderer" (home/main.tsx).
-     */
-    fromProcess: "main" | "renderer";
+    main?: {
+        /**
+         * API calls available to the extension when running inside the main process.
+         */
+    };
 
-    /**
-     * Renderer only: require a third-party module (e.g. "mobx") by name, for
-     * runtime-loaded extensions which cannot resolve node packages through
-     * node module resolution. Only modules explicitly registered by the host
-     * via setExtensionApiModules are available; anything else throws.
-     * Studio-own modules are NOT exposed this way — they don't have a stable
-     * API; the parts extensions need are exported as explicit members below
-     * instead, so each addition is visible and reviewed.
-     */
-    requireModule?(name: string): any;
+    renderer?: {
+        /**
+         * API calls available to the extension when running inside the renderer process.
+         */
 
-    /**
-     * Renderer only: the list of open projects, one entry per project editor
-     * tab. Best-effort export: it tracks Studio internals and may change
-     * between releases — extensions should feature-detect.
-     */
-    getOpenProjects?(): IOpenProjectInfo[];
+        /**
+         * Require a third-party module (e.g. "mobx") by name, for
+         * runtime-loaded extensions which cannot resolve node packages through
+         * node module resolution. Only modules explicitly registered by the host
+         * via setExtensionApiModules are available; anything else throws.
+         * Studio-own modules are NOT exposed this way — they don't have a stable
+         * API; the parts extensions need are exported as explicit members below
+         * instead, so each addition is visible and reviewed.
+         */
+        requireModule?(name: string): any;
 
-    /**
-     * Renderer only: the ProjectStore of the currently selected project
-     * editor tab, or undefined when no project editor is open. Best-effort
-     * export: it tracks Studio internals (project-editor/store) and may
-     * change between releases — extensions should feature-detect.
-     */
-    getActiveProjectStore?(): any;
+        /**
+         * The list of open projects, one entry per project editor
+         * tab. Best-effort export: it tracks Studio internals and may change
+         * between releases — extensions should feature-detect.
+         */
+        getOpenProjects?(): IOpenProjectInfo[];
+
+        /**
+         * The ProjectStore of the currently selected project
+         * editor tab, or undefined when no project editor is open. Best-effort
+         * export: it tracks Studio internals (project-editor/store) and may
+         * change between releases — extensions should feature-detect.
+         */
+        getActiveProjectStore?(): any;
+    }
 }
 
 export type ExtensionType =

--- a/packages/eez-studio-shared/extensions/extension.ts
+++ b/packages/eez-studio-shared/extensions/extension.ts
@@ -155,6 +155,18 @@ export interface IExtensionHost {
 }
 
 /**
+ * One entry of the open-projects list (see IExtensionApi.getOpenProjects).
+ */
+export interface IOpenProjectInfo {
+    /** File base name of the .eez-project file. */
+    name: string;
+    /** Absolute path of the .eez-project file. */
+    filePath: string | undefined;
+    /** Whether this project's editor tab is the currently selected one. */
+    active: boolean;
+}
+
+/**
  * API object passed to IExtensionDefinition.initExtension.
  */
 export interface IExtensionApi {
@@ -165,13 +177,30 @@ export interface IExtensionApi {
     fromProcess: "main" | "renderer";
 
     /**
-     * Renderer only: access explicitly exported Studio modules by name
-     * (e.g. "project-editor/store"). The module must be whitelisted by the
-     * host via setExtensionApiModules; unknown names throw. This is how
-     * runtime-loaded extensions (which cannot resolve Studio packages
-     * through node module resolution) reach editor internals.
+     * Renderer only: require a third-party module (e.g. "mobx") by name, for
+     * runtime-loaded extensions which cannot resolve node packages through
+     * node module resolution. Only modules explicitly registered by the host
+     * via setExtensionApiModules are available; anything else throws.
+     * Studio-own modules are NOT exposed this way — they don't have a stable
+     * API; the parts extensions need are exported as explicit members below
+     * instead, so each addition is visible and reviewed.
      */
     requireModule?(name: string): any;
+
+    /**
+     * Renderer only: the list of open projects, one entry per project editor
+     * tab. Best-effort export: it tracks Studio internals and may change
+     * between releases — extensions should feature-detect.
+     */
+    getOpenProjects?(): IOpenProjectInfo[];
+
+    /**
+     * Renderer only: the ProjectStore of the currently selected project
+     * editor tab, or undefined when no project editor is open. Best-effort
+     * export: it tracks Studio internals (project-editor/store) and may
+     * change between releases — extensions should feature-detect.
+     */
+    getActiveProjectStore?(): any;
 }
 
 export type ExtensionType =

--- a/packages/eez-studio-shared/extensions/extension.ts
+++ b/packages/eez-studio-shared/extensions/extension.ts
@@ -163,6 +163,15 @@ export interface IExtensionApi {
      * "renderer" (home/main.tsx).
      */
     fromProcess: "main" | "renderer";
+
+    /**
+     * Renderer only: access explicitly exported Studio modules by name
+     * (e.g. "project-editor/store"). The module must be whitelisted by the
+     * host via setExtensionApiModules; unknown names throw. This is how
+     * runtime-loaded extensions (which cannot resolve Studio packages
+     * through node module resolution) reach editor internals.
+     */
+    requireModule?(name: string): any;
 }
 
 export type ExtensionType =

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -137,9 +137,29 @@ export function setExtensionsFromProcess(value: FromProcess) {
     fromProcess = value;
 }
 
+// Modules the host explicitly exports to renderer-side extensions
+// (see IExtensionApi.requireModule). Registered by the renderer entry
+// point before loadExtensions.
+let apiModules: { [name: string]: any } | undefined;
+
+export function setExtensionApiModules(modules: { [name: string]: any }) {
+    apiModules = modules;
+}
+
 export function registerExtension(extension: IExtension) {
     if (extension.init) {
-        extension.init({ fromProcess });
+        const api: IExtensionApi = { fromProcess };
+        if (apiModules && fromProcess === "renderer") {
+            api.requireModule = (name: string) => {
+                if (!Object.prototype.hasOwnProperty.call(apiModules!, name)) {
+                    throw new Error(
+                        `module not exported to extensions: ${name}`
+                    );
+                }
+                return apiModules![name];
+            };
+        }
+        extension.init(api);
     }
 
     action(() => extensions.set(extension.id, extension))();

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -131,9 +131,6 @@ let extensionApi: IExtensionApi | undefined;
 function getExtensionApi(): IExtensionApi {
     if (!extensionApi) {
         if (isRenderer()) {
-            const { tabs, ProjectEditorTab } =
-                require("home/tabs-store") as typeof import("home/tabs-store");
-
             extensionApi = {
                 renderer: {
                     requireModule: (name: string) => {
@@ -145,27 +142,36 @@ function getExtensionApi(): IExtensionApi {
                             );
                         }
                     },
-                    getOpenProjects: () =>
-                        tabs.tabs
+                    // The tabs-store singleton is created lazily by loadTabs()
+                    // (after loadExtensions), so the module has to be required
+                    // inside the calls — capturing its exports at
+                    // extension-registration time would freeze `tabs` at
+                    // undefined.
+                    getOpenProjects: () => {
+                        const { tabs, ProjectEditorTab } =
+                            require("home/tabs-store") as typeof import("home/tabs-store");
+                        return tabs.tabs
                             .filter(tab => tab instanceof ProjectEditorTab)
                             .map(tab => ({
                                 name: path.basename(tab.filePath ?? ""),
                                 filePath: tab.filePath,
                                 active: tab === tabs.activeTab
-                            })),
-                    getActiveProjectStore: () =>
-                        tabs.activeTab instanceof ProjectEditorTab
+                            }));
+                    },
+                    getActiveProjectStore: () => {
+                        const { tabs, ProjectEditorTab } =
+                            require("home/tabs-store") as typeof import("home/tabs-store");
+                        return tabs.activeTab instanceof ProjectEditorTab
                             ? tabs.activeTab.projectStore
-                            : undefined
-                }   
+                            : undefined;
+                    }
+                }
             };
         } else {
             extensionApi = {
                 main: {}
             };
         }
-        
-        console.log(extensionApi);
     }
 
     return extensionApi;

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -137,27 +137,50 @@ export function setExtensionsFromProcess(value: FromProcess) {
     fromProcess = value;
 }
 
-// Modules the host explicitly exports to renderer-side extensions
-// (see IExtensionApi.requireModule). Registered by the renderer entry
-// point before loadExtensions.
+// Third-party modules the host explicitly exports to renderer-side
+// extensions (see IExtensionApi.requireModule). Registered by the renderer
+// entry point before loadExtensions.
 let apiModules: { [name: string]: any } | undefined;
 
 export function setExtensionApiModules(modules: { [name: string]: any }) {
     apiModules = modules;
 }
 
+// Implementations of the renderer-only IExtensionApi members that export
+// Studio internals (getOpenProjects, getActiveProjectStore, ...). Registered
+// by the renderer entry point (home/main.tsx) before loadExtensions, so each
+// piece of Studio handed to extensions is defined in one reviewable place.
+let rendererApiMembers:
+    | Partial<
+          Pick<IExtensionApi, "getOpenProjects" | "getActiveProjectStore">
+      >
+    | undefined;
+
+export function setExtensionApiRendererMembers(
+    members: NonNullable<typeof rendererApiMembers>
+) {
+    rendererApiMembers = members;
+}
+
 export function registerExtension(extension: IExtension) {
     if (extension.init) {
         const api: IExtensionApi = { fromProcess };
-        if (apiModules && fromProcess === "renderer") {
-            api.requireModule = (name: string) => {
-                if (!Object.prototype.hasOwnProperty.call(apiModules!, name)) {
-                    throw new Error(
-                        `module not exported to extensions: ${name}`
-                    );
-                }
-                return apiModules![name];
-            };
+        if (fromProcess === "renderer") {
+            if (apiModules) {
+                api.requireModule = (name: string) => {
+                    if (
+                        !Object.prototype.hasOwnProperty.call(apiModules!, name)
+                    ) {
+                        throw new Error(
+                            `module not exported to extensions: ${name}`
+                        );
+                    }
+                    return apiModules![name];
+                };
+            }
+            if (rendererApiMembers) {
+                Object.assign(api, rendererApiMembers);
+            }
         }
         extension.init(api);
     }

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -11,7 +11,8 @@ import {
     readJsObjectFromFile,
     removeFolder,
     renameFile,
-    readFolder
+    readFolder,
+    isRenderer
 } from "eez-studio-shared/util-electron";
 import { guid } from "eez-studio-shared/guid";
 import { firstWord } from "eez-studio-shared/string";
@@ -61,9 +62,9 @@ async function loadExtension(
                     if (mainScript) {
                         // this is measurement functions extension
                         extensionType = "measurement-functions";
-                        extension = require(extensionFolderPath +
-                            "/" +
-                            mainScript).default;
+                        extension = require(
+                            extensionFolderPath + "/" + mainScript
+                        ).default;
                     } else if (
                         packageJsonEezStudio[CONF_NODE_MODULE_PROPERTY_NAME]
                     ) {
@@ -125,64 +126,54 @@ async function loadExtension(
     return undefined;
 }
 
-export type FromProcess = IExtensionApi["fromProcess"];
+let extensionApi: IExtensionApi | undefined;
 
-// Which process is loading extensions. Both the main process (main/setup.ts)
-// and the renderer (home/main.tsx) load the installed extensions;
-// initExtension uses this to tell them apart. Renderer is the default so
-// existing entry points keep their current behavior.
-let fromProcess: FromProcess = "renderer";
+function getExtensionApi(): IExtensionApi {
+    if (!extensionApi) {
+        if (isRenderer()) {
+            const { tabs, ProjectEditorTab } =
+                require("home/tabs-store") as typeof import("home/tabs-store");
 
-export function setExtensionsFromProcess(value: FromProcess) {
-    fromProcess = value;
-}
+            extensionApi = {
+                renderer: {
+                    requireModule: (name: string) => {
+                        if (name == "mobx") {
+                            return require("mobx");
+                        } else {
+                            throw new Error(
+                                `module not exported to extensions: ${name}`
+                            );
+                        }
+                    },
+                    getOpenProjects: () =>
+                        tabs.tabs
+                            .filter(tab => tab instanceof ProjectEditorTab)
+                            .map(tab => ({
+                                name: path.basename(tab.filePath ?? ""),
+                                filePath: tab.filePath,
+                                active: tab === tabs.activeTab
+                            })),
+                    getActiveProjectStore: () =>
+                        tabs.activeTab instanceof ProjectEditorTab
+                            ? tabs.activeTab.projectStore
+                            : undefined
+                }   
+            };
+        } else {
+            extensionApi = {
+                main: {}
+            };
+        }
+        
+        console.log(extensionApi);
+    }
 
-// Third-party modules the host explicitly exports to renderer-side
-// extensions (see IExtensionApi.requireModule). Registered by the renderer
-// entry point before loadExtensions.
-let apiModules: { [name: string]: any } | undefined;
-
-export function setExtensionApiModules(modules: { [name: string]: any }) {
-    apiModules = modules;
-}
-
-// Implementations of the renderer-only IExtensionApi members that export
-// Studio internals (getOpenProjects, getActiveProjectStore, ...). Registered
-// by the renderer entry point (home/main.tsx) before loadExtensions, so each
-// piece of Studio handed to extensions is defined in one reviewable place.
-let rendererApiMembers:
-    | Partial<
-          Pick<IExtensionApi, "getOpenProjects" | "getActiveProjectStore">
-      >
-    | undefined;
-
-export function setExtensionApiRendererMembers(
-    members: NonNullable<typeof rendererApiMembers>
-) {
-    rendererApiMembers = members;
+    return extensionApi;
 }
 
 export function registerExtension(extension: IExtension) {
     if (extension.init) {
-        const api: IExtensionApi = { fromProcess };
-        if (fromProcess === "renderer") {
-            if (apiModules) {
-                api.requireModule = (name: string) => {
-                    if (
-                        !Object.prototype.hasOwnProperty.call(apiModules!, name)
-                    ) {
-                        throw new Error(
-                            `module not exported to extensions: ${name}`
-                        );
-                    }
-                    return apiModules![name];
-                };
-            }
-            if (rendererApiMembers) {
-                Object.assign(api, rendererApiMembers);
-            }
-        }
-        extension.init(api);
+        extension.init(getExtensionApi());
     }
 
     action(() => extensions.set(extension.id, extension))();

--- a/packages/home/main.tsx
+++ b/packages/home/main.tsx
@@ -1,5 +1,6 @@
 /// <reference path="./globals.d.ts"/>
 import "bootstrap";
+import path from "path";
 import { ipcRenderer } from "electron";
 import React from "react";
 import { createRoot } from "react-dom/client";
@@ -8,7 +9,8 @@ import { observer } from "mobx-react";
 
 import {
     loadExtensions,
-    setExtensionApiModules
+    setExtensionApiModules,
+    setExtensionApiRendererMembers
 } from "eez-studio-shared/extensions/extensions";
 import { getNodeModuleFolders } from "eez-studio-shared/extensions/yarn";
 
@@ -172,13 +174,29 @@ async function main() {
         nodeModuleFolders = [];
     }
 
-    // Modules explicitly exported to renderer-side extensions
-    // (api.requireModule). Extend this list as extensions need more.
+    // Third-party modules exported to renderer-side extensions
+    // (api.requireModule). Studio-own modules are deliberately NOT on this
+    // list: they have no stable API, so the parts extensions need are
+    // exported as explicit IExtensionApi members below instead.
     setExtensionApiModules({
-        mobx: require("mobx"),
-        "project-editor/store": require("project-editor/store"),
-        "project-editor/core/object": require("project-editor/core/object"),
-        "home/tabs-store": require("home/tabs-store")
+        mobx: require("mobx")
+    });
+
+    // Studio internals exported to renderer-side extensions, one explicit
+    // member per reviewed addition (see IExtensionApi). Extend through PRs.
+    setExtensionApiRendererMembers({
+        getOpenProjects: () =>
+            tabs.tabs
+                .filter(tab => tab instanceof ProjectEditorTab)
+                .map(tab => ({
+                    name: path.basename(tab.filePath ?? ""),
+                    filePath: tab.filePath,
+                    active: tab === tabs.activeTab
+                })),
+        getActiveProjectStore: () =>
+            tabs.activeTab instanceof ProjectEditorTab
+                ? tabs.activeTab.projectStore
+                : undefined
     });
 
     await loadExtensions(nodeModuleFolders);

--- a/packages/home/main.tsx
+++ b/packages/home/main.tsx
@@ -1,6 +1,5 @@
 /// <reference path="./globals.d.ts"/>
 import "bootstrap";
-import path from "path";
 import { ipcRenderer } from "electron";
 import React from "react";
 import { createRoot } from "react-dom/client";
@@ -8,9 +7,7 @@ import { configure } from "mobx";
 import { observer } from "mobx-react";
 
 import {
-    loadExtensions,
-    setExtensionApiModules,
-    setExtensionApiRendererMembers
+    loadExtensions
 } from "eez-studio-shared/extensions/extensions";
 import { getNodeModuleFolders } from "eez-studio-shared/extensions/yarn";
 
@@ -173,31 +170,6 @@ async function main() {
         console.info(`Failed to get node module folders.`);
         nodeModuleFolders = [];
     }
-
-    // Third-party modules exported to renderer-side extensions
-    // (api.requireModule). Studio-own modules are deliberately NOT on this
-    // list: they have no stable API, so the parts extensions need are
-    // exported as explicit IExtensionApi members below instead.
-    setExtensionApiModules({
-        mobx: require("mobx")
-    });
-
-    // Studio internals exported to renderer-side extensions, one explicit
-    // member per reviewed addition (see IExtensionApi). Extend through PRs.
-    setExtensionApiRendererMembers({
-        getOpenProjects: () =>
-            tabs.tabs
-                .filter(tab => tab instanceof ProjectEditorTab)
-                .map(tab => ({
-                    name: path.basename(tab.filePath ?? ""),
-                    filePath: tab.filePath,
-                    active: tab === tabs.activeTab
-                })),
-        getActiveProjectStore: () =>
-            tabs.activeTab instanceof ProjectEditorTab
-                ? tabs.activeTab.projectStore
-                : undefined
-    });
 
     await loadExtensions(nodeModuleFolders);
 

--- a/packages/home/main.tsx
+++ b/packages/home/main.tsx
@@ -6,7 +6,10 @@ import { createRoot } from "react-dom/client";
 import { configure } from "mobx";
 import { observer } from "mobx-react";
 
-import { loadExtensions } from "eez-studio-shared/extensions/extensions";
+import {
+    loadExtensions,
+    setExtensionApiModules
+} from "eez-studio-shared/extensions/extensions";
 import { getNodeModuleFolders } from "eez-studio-shared/extensions/yarn";
 
 import * as notification from "eez-studio-ui/notification";
@@ -168,6 +171,15 @@ async function main() {
         console.info(`Failed to get node module folders.`);
         nodeModuleFolders = [];
     }
+
+    // Modules explicitly exported to renderer-side extensions
+    // (api.requireModule). Extend this list as extensions need more.
+    setExtensionApiModules({
+        mobx: require("mobx"),
+        "project-editor/store": require("project-editor/store"),
+        "project-editor/core/object": require("project-editor/core/object"),
+        "home/tabs-store": require("home/tabs-store")
+    });
 
     await loadExtensions(nodeModuleFolders);
 

--- a/packages/main/setup.ts
+++ b/packages/main/setup.ts
@@ -1,13 +1,8 @@
 import { getUserDataPath, makeFolder } from "eez-studio-shared/util-electron";
 import { EXTENSIONS_FOLDER_NAME } from "eez-studio-shared/conf";
-import {
-    loadExtensions,
-    setExtensionsFromProcess
-} from "eez-studio-shared/extensions/extensions";
+import { loadExtensions } from "eez-studio-shared/extensions/extensions";
 
 export async function setup() {
-    setExtensionsFromProcess("main");
-
     const extensionsFolderPath = getUserDataPath(EXTENSIONS_FOLDER_NAME);
     await makeFolder(extensionsFolderPath);
 

--- a/packages/project-editor/flow/components/widgets/dashboard/index.tsx
+++ b/packages/project-editor/flow/components/widgets/dashboard/index.tsx
@@ -296,6 +296,10 @@ registerClass("RectangleDashboardWidget", RectangleDashboardWidget);
 
 ////////////////////////////////////////////////////////////////////////////////
 
+class TextInputWidgetExecutionState {
+    focus?: () => void;
+}
+
 const TextInputWidgetInput = observer(
     class TextInputWidgetInput extends React.Component<{
         value: string;
@@ -316,6 +320,22 @@ const TextInputWidgetInput = observer(
             makeObservable(this, {
                 inputValue: observable
             });
+        }
+
+        componentDidMount() {
+            if (this.props.flowContext.flowState && this.inputElement.current) {
+                this.inputElement.current.focus();
+            }
+
+            let executionState =
+                this.props.flowContext.flowState?.getComponentExecutionState<TextInputWidgetExecutionState>(
+                    this.props.textInputWidget
+                );
+            if (executionState) {
+                executionState.focus = () => {
+                    this.inputElement.current?.focus();
+                };
+            }
         }
 
         handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -495,6 +515,18 @@ export class TextInputWidget extends Widget {
                 code: 2,
                 paramExpressionType: `struct:${TEXT_INPUT_CHANGE_EVENT_STRUCT_NAME}`,
                 oldName: "onChange"
+            }
+        },
+
+        execute: (context: IDashboardComponentContext) => {
+            Widget.classInfo.execute!(context);
+
+            let executionState =
+                context.getComponentExecutionState<TextInputWidgetExecutionState>();
+            if (!executionState) {
+                context.setComponentExecutionState<TextInputWidgetExecutionState>(
+                    new TextInputWidgetExecutionState()
+                );
             }
         }
     });


### PR DESCRIPTION
Follow-up to #1043 (init(api)). Reworked per review: ~~generic requireModule for Studio modules~~ → **Studio internals are exported as explicit, reviewed `IExtensionApi` members**; `requireModule` remains for third-party packages only (e.g. `mobx`), since runtime-loaded extensions cannot resolve node packages through node module resolution.

### What extensions get in the renderer

```ts
export interface IExtensionApi {
    fromProcess: "main" | "renderer";

    // Third-party packages only, host-registered allow-list:
    requireModule?(name: string): any;                  // "mobx", ...

    // Studio internals, one explicit member per reviewed addition:
    getOpenProjects?(): IOpenProjectInfo[];              // open project editor tabs
    getActiveProjectStore?(): any;                       // ProjectStore of the selected tab
}
```

Both are best-effort exports documented as tracking Studio internals; extensions feature-detect. Studio-own modules are deliberately **not** on the `requireModule` allow-list — they have no stable API, and this way every piece of Studio handed to extensions is visible in `home/main.tsx` (`setExtensionApiRendererMembers` / `setExtensionApiModules`) and each future addition (undoable object edits, checks/output, screenshots, wasm preview, ...) arrives as an explicit, reviewable PR adding one member.

### Why an extension needs this at all

The MCP bridge extension ([IWILLTBEST/eez-studio-mcp](https://github.com/IWILLTBEST/eez-studio-mcp)) reports real editor state (open projects) and will progressively gain editing tools. Without any export path, a runtime-loaded extension cannot reach any Studio code (see #1042 for the background discussion).

Closes nothing on its own; first increment of the surface discussed in #1042.