### PR TITLE
[LVGL] Support T"..." translated expressions, resolved by lv_i18n

### DIFF
--- a/packages/project-editor/build/assets.ts
+++ b/packages/project-editor/build/assets.ts
@@ -180,6 +180,10 @@ export class Assets {
         [componentType: number]: string;
     } = {};
 
+    // text ids used in T"..." expressions, collected during the flow build
+    // (LVGL only), emitted in screens.c for "lv_i18n extract"
+    lvglTranslatedTextIds = new Set<string>();
+
     isUsingCrypyoSha256: boolean = false;
 
     lvglBuild: LVGLBuild;

--- a/packages/project-editor/flow/expression/build.ts
+++ b/packages/project-editor/flow/expression/build.ts
@@ -163,6 +163,25 @@ function buildExpressionNode(
     }
 
     if (node.type == "TextResource") {
+        if (assets.projectStore.projectTypeTraits.isLVGL) {
+            // Translated by an external library (e.g. lv_i18n) through the
+            // translate hook on the target. The simulator has no hook, so
+            // it is given only the text resource ID.
+            if (assets.option == "buildFiles") {
+                return [
+                    makePushConstantInstruction(
+                        assets,
+                        node.value,
+                        node.valueType
+                    ),
+                    makeOperationInstruction(operationIndexes["Flow.translate"])
+                ];
+            }
+            return [
+                makePushConstantInstruction(assets, node.value, node.valueType)
+            ];
+        }
+
         if (assets.projectStore.project.texts) {
             return [
                 makePushConstantInstruction(

--- a/packages/project-editor/flow/expression/build.ts
+++ b/packages/project-editor/flow/expression/build.ts
@@ -167,6 +167,7 @@ function buildExpressionNode(
             // Translated by an external library (e.g. lv_i18n) through the
             // translate hook on the target. The simulator has no hook, so
             // it is given only the text resource ID.
+            assets.lvglTranslatedTextIds.add(node.value);
             if (assets.option == "buildFiles") {
                 return [
                     makePushConstantInstruction(

--- a/packages/project-editor/flow/expression/check.ts
+++ b/packages/project-editor/flow/expression/check.ts
@@ -111,6 +111,12 @@ function checkExpressionNode(component: Component, rootNode: ExpressionNode) {
         if (node.type == "TextResource") {
             const project = ProjectEditor.getProject(component);
 
+            if (project.projectTypeTraits.isLVGL) {
+                // translated by an external library (e.g. lv_i18n),
+                // there is no text resource catalog inside the project
+                return;
+            }
+
             if (
                 !project.texts ||
                 !project.texts.resources.find(

--- a/packages/project-editor/flow/expression/eval.ts
+++ b/packages/project-editor/flow/expression/eval.ts
@@ -182,6 +182,12 @@ function evalConstantExpressionNode(
         }
 
         if (node.type == "TextResource") {
+            if (project.projectTypeTraits.isLVGL) {
+                // translated by an external library (e.g. lv_i18n),
+                // show the text resource ID in the editor
+                return node.value;
+            }
+
             const textResource = project.texts.resources.find(
                 textResource => textResource.resourceID == node.value
             );

--- a/packages/project-editor/lvgl/build.ts
+++ b/packages/project-editor/lvgl/build.ts
@@ -2362,6 +2362,26 @@ export class LVGLBuild extends Build {
         }
         build.blockEnd("}");
 
+        if (this.assets.lvglTranslatedTextIds.size > 0) {
+            build.line("");
+            build.line(
+                "// This function is never called. It lists the texts used in"
+            );
+            build.line(
+                '// EEZ Flow expressions, so that "lv_i18n extract" can find'
+            );
+            build.line("// them.");
+            build.line("#ifdef _");
+            build.line("void eez_flow_translatable_texts() {");
+            for (const textId of [
+                ...this.assets.lvglTranslatedTextIds
+            ].sort()) {
+                build.line(`    _(${escapeCString(textId)});`);
+            }
+            build.line("}");
+            build.line("#endif");
+        }
+
         return this.result;
     }
 


### PR DESCRIPTION
This PR adds support for translated string literals (T"...") inside EEZ Flow expressions in LVGL projects, resolved at runtime by an external translation library - typically [lv_i18n](https://github.com/lvgl/lv_i18n) - instead of a translation catalog stored in the project. It completes the existing "Translated literal".

Addresses the expression part of #274, as requested in the issue discussion:
> We also need to add support through expressions. So you can write something like this:
>
> ```
> T"Voltage: " + volt_var
> ```
>
> Here syntax will be `T"..."` since this is already how we use it in EEZ-GUI and Dashboard projects.

## What it does
 
- `T"textId"` is accepted by the expression checker without any catalog (no more `text resource ID not found`).
- In the firmware build it compiles to bytecode resolved through a new engine hook. Wiring is one line in `main.c`:
```c
  display = bsp_display_init();
  ui_init();
  lv_i18n_init(lv_i18n_language_pack);
  lv_i18n_set_locale("fr-FR");
  eez_flow_set_translate_hook(lv_i18n_get_text);
```
 
  Without a hook, the raw text id is used. Changing locale at runtime is picked up on the next tick, since `tick_screen_*` already compares and updates expression-driven properties.
- `lv_i18n extract` finds the ids. Because the extractor regex-scans C sources for `_("...")` and cannot see the flow bytecode, the build appends to `screens.c` a function that is never called:
```c
  #ifdef _
  void eez_flow_translatable_texts() {
      _("greeting");
      _("voltage");
  }
  #endif
```
 
  The `#ifdef _` guard keeps the file compilable without lv_i18n (the extractor ignores the preprocessor, the compiler does not). Ids are deduplicated and sorted; the block is omitted when no `T"..."` is used. The usual `lv_i18n extract` / `compile` workflow is unchanged.
- In the editor and the simulator the raw id is shown, as "Translated literal" already does today.


## Out of scope
- **Plurals** — there is no expression syntax for `_p("id", n)` yet.

## How to test
 
1. In an LVGL project with Flow support, set a Label's Text to *Expression* and enter `T"greeting" + " 42"` - no error, editor and simulator show the raw id.
2. Build: `screens.c` ends with the `eez_flow_translatable_texts()` block; `lv_i18n extract` picks up `greeting`.
3. Add `eez_flow_set_translate_hook(lv_i18n_get_text);` in `main.c` - the label shows the translation and follows `lv_i18n_set_locale(...)` at runtime.
