### PR TITLE
Extension API: Batch-2 renderer members (option B from #1042)

### DIFF
--- a/packages/eez-studio-shared/extensions/extension.ts
+++ b/packages/eez-studio-shared/extensions/extension.ts
@@ -210,6 +210,91 @@ export interface IExtensionApi {
          * change between releases — extensions should feature-detect.
          */
         getActiveProjectStore?(): any;
+
+        /**
+         * Make the project editor tab for `filePath` the selected tab
+         * (same code path as the user clicking the tab). No-op when it is
+         * already selected. Path comparison is case-insensitive and
+         * slash-insensitive. Throws when no open tab matches.
+         */
+        activateProjectTab?(filePath: string): void;
+
+        /**
+         * Open a project file in a new editor tab (or select the existing
+         * tab when one is already open for it). Same code path as File →
+         * Open Project.
+         */
+        openProject?(filePath: string, runMode?: boolean): void;
+
+        /**
+         * The editor object-model layer: object construction, the class
+         * registry, tree traversal and object paths. Best-effort export of
+         * project-editor/store, project-editor/core/object and
+         * project-editor/core/search — it tracks Studio internals and may
+         * change between releases; extensions should feature-detect.
+         */
+        getEditorObjectToolkit?(): {
+            /** Construct an EezObject of aClass from a plain object. */
+            createObject(
+                projectStore: any,
+                jsObject: any,
+                aClass: any,
+                key?: string
+            ): any;
+            /** Look up a registered editor class by name. */
+            getClassByName(projectStore: any, className: string): any;
+            /** All registered classes derived from parentClass. */
+            getClassesDerivedFrom(projectStore: any, parentClass: any): any[];
+            /** The default value for a property of classInfo. */
+            getDefaultValue(projectStore: any, classInfo: any): any;
+            /** Set an object's parent (owner link for getObjectPath). */
+            setParent(object: any, parentObject: any): void;
+            /** Iterate every EezObject in the tree rooted at root. */
+            visitObjects(root: any): Iterable<any>;
+            /** Path segments of an object, e.g. ["userPages", 0, "components"]. */
+            getObjectPath(object: any): (string | number)[];
+            /** Path of an object as a string, e.g. "/userPages/0/components". */
+            getObjectPathAsString(object: any): string;
+        };
+
+        /**
+         * The LVGL widget/style layer. Best-effort export of
+         * project-editor/lvgl/style, lvgl/style-catalog,
+         * lvgl/widgets/Base, features/page/page and features/style/theme —
+         * it tracks Studio internals and may change between releases;
+         * extensions should feature-detect.
+         */
+        getLvglToolkit?(): {
+            /** Base class of every LVGL widget (for class derivation walks). */
+            LVGLWidget: any;
+            /** Class of named LVGL styles. */
+            LVGLStyle: any;
+            /** Class of pages (user widgets / screens). */
+            Page: any;
+            /** Color value class. */
+            Color: any;
+            /** Built-in font descriptors (Montserrat sizes). */
+            BUILT_IN_FONTS: any;
+        };
+
+        /**
+         * The font/bitmap asset layer. Best-effort export of
+         * project-editor/features/font/font, font-extract and
+         * features/bitmap/bitmap — it tracks Studio internals and may
+         * change between releases; extensions should feature-detect.
+         */
+        getAssetToolkit?(): {
+            /** Font asset class. */
+            Font: any;
+            /** Extract a TTF's glyphs/subset for a new font asset. */
+            extractFont: any;
+            /** Parse LVGL ranges/symbols strings into encodings + symbol set. */
+            getLvglEncodingsAndSymbols: any;
+            /** Bitmap asset class. */
+            Bitmap: any;
+            /** Create a bitmap asset from an image file. */
+            createBitmap: any;
+        };
     }
 }
 

--- a/packages/eez-studio-shared/extensions/extensions.ts
+++ b/packages/eez-studio-shared/extensions/extensions.ts
@@ -164,6 +164,80 @@ function getExtensionApi(): IExtensionApi {
                         return tabs.activeTab instanceof ProjectEditorTab
                             ? tabs.activeTab.projectStore
                             : undefined;
+                    },
+                    activateProjectTab: (filePath: string) => {
+                        const { tabs, ProjectEditorTab } =
+                            require("home/tabs-store") as typeof import("home/tabs-store");
+                        const normalize = (p?: string) =>
+                            p?.replace(/\\/g, "/").toLowerCase();
+                        const tab = tabs.tabs.find(
+                            tab =>
+                                tab instanceof ProjectEditorTab &&
+                                normalize(tab.filePath) ===
+                                    normalize(filePath)
+                        );
+                        if (!tab) {
+                            throw new Error(
+                                `no open project tab for ${filePath}`
+                            );
+                        }
+                        if (tabs.activeTab !== tab) {
+                            tab.makeActive();
+                        }
+                    },
+                    openProject: (filePath: string, runMode?: boolean) => {
+                        const { openProject } =
+                            require("home/tabs-store") as typeof import("home/tabs-store");
+                        return openProject(filePath, !!runMode);
+                    },
+                    // Toolkits below re-export project-editor symbols the
+                    // same lazy way — required at call time, so nothing is
+                    // frozen at extension-registration time.
+                    // 下述 toolkit 同样在调用时才 require，避免注册期冻结导出。
+                    getEditorObjectToolkit: () => {
+                        const store =
+                            require("project-editor/store") as typeof import("project-editor/store");
+                        const object =
+                            require("project-editor/core/object") as typeof import("project-editor/core/object");
+                        const search =
+                            require("project-editor/core/search") as typeof import("project-editor/core/search");
+                        return {
+                            createObject: store.createObject,
+                            getClassByName: object.getClassByName,
+                            getClassesDerivedFrom: object.getClassesDerivedFrom,
+                            getDefaultValue: object.getDefaultValue,
+                            setParent: object.setParent,
+                            visitObjects: search.visitObjects,
+                            getObjectPath: store.getObjectPath,
+                            getObjectPathAsString: store.getObjectPathAsString
+                        };
+                    },
+                    getLvglToolkit: () => ({
+                        LVGLWidget:
+                            require("project-editor/lvgl/widgets/Base").LVGLWidget,
+                        LVGLStyle: require("project-editor/lvgl/style").LVGLStyle,
+                        Page: require("project-editor/features/page/page").Page,
+                        Color:
+                            require("project-editor/features/style/theme").Color,
+                        BUILT_IN_FONTS:
+                            require("project-editor/lvgl/style-catalog")
+                                .BUILT_IN_FONTS
+                    }),
+                    getAssetToolkit: () => {
+                        const font =
+                            require("project-editor/features/font/font") as any;
+                        const fontExtract =
+                            require("project-editor/features/font/font-extract") as any;
+                        const bitmap =
+                            require("project-editor/features/bitmap/bitmap") as any;
+                        return {
+                            Font: font.Font,
+                            extractFont: fontExtract.extractFont,
+                            getLvglEncodingsAndSymbols:
+                                font.getLvglEncodingsAndSymbols,
+                            Bitmap: bitmap.Bitmap,
+                            createBitmap: bitmap.createBitmap
+                        };
                     }
                 }
             };


### PR DESCRIPTION
Implements the option-B shape from #1042 — extending the renderer API function by function, one reviewed member at a time. Every piece below is an independent commit-level unit; drop any of them if unwanted and the rest still stands.

### Tab management (closes the getOpenProjects data-copy gap)

- `activateProjectTab(filePath)` — make another open project editor tab the selected one (same code path as clicking the tab). Case- and slash-insensitive path match, no-op when already selected, throws when no tab matches. `getOpenProjects()` only returns data copies, so without this member an extension cannot change which project it is addressing.
- `openProject(filePath, runMode?)` — File → Open Project code path; opens a new editor tab or selects the existing one.

### Capability toolkits (the module-level layers from the #1042 table)

- `getEditorObjectToolkit()` — `createObject`, `getClassByName`, `getClassesDerivedFrom`, `getDefaultValue`, `setParent`, `visitObjects`, `getObjectPath`/`getObjectPathAsString`: object construction, class registry, tree walk, object paths (objID addressing, create_widget/create_screen).
- `getLvglToolkit()` — `LVGLWidget`, `LVGLStyle`, `Page`, `Color`, `BUILT_IN_FONTS`: the widget/style layer (style + theme tools).
- `getAssetToolkit()` — `Font`, `extractFont`, `Bitmap`, `createBitmap`: the asset layer (add_font / add_image).

All implementations `require` their modules at call time, same pattern as the tabs-store lazy-init fix merged in #1044 — nothing is captured at extension-registration time. All members are optional and typed `any`-loose with best-effort docs, consistent with the existing ones.

### Verified end-to-end

With these members the MCP bridge extension ([IWILLTBEST/eez-studio-mcp](https://github.com/IWILLTBEST/eez-studio-mcp)) gets full multi-project support: `select_project` switches tabs and subsequent tools address the newly active project (tested switching between three open projects, including Windows backslash paths). The toolkits unblock the remaining ~30 tools (widget/style/asset classes) — port tracked in that repo.