### PR TITLE
[LVGL] Add Chart widget properties (series, ranges, point and div line counts)

### DIFF
--- a/packages/project-editor/lvgl/lvgl-constants.ts
+++ b/packages/project-editor/lvgl/lvgl-constants.ts
@@ -727,6 +727,12 @@ export const ROLLER_MODES = {
     INFINITE: 1
 };
 
+// lv_chart_axis_t
+export const LV_CHART_AXIS = {
+    PRIMARY_Y: 0,
+    SECONDARY_Y: 1
+};
+
 // lv_bar_mode_t
 export const BAR_MODES = {
     NORMAL: 0,
@@ -863,6 +869,9 @@ export const LVGL_CONSTANTS_ALL = {
     LV_BAR_MODE_NORMAL: 0,
     LV_BAR_MODE_SYMMETRICAL: 1,
     LV_BAR_MODE_RANGE: 2,
+
+    LV_CHART_AXIS_PRIMARY_Y: 0,
+    LV_CHART_AXIS_SECONDARY_Y: 1,
 
     LV_COLORWHEEL_MODE_HUE: 0,
     LV_COLORWHEEL_MODE_SATURATION: 1,

--- a/packages/project-editor/lvgl/widgets/Chart.tsx
+++ b/packages/project-editor/lvgl/widgets/Chart.tsx
@@ -329,7 +329,9 @@ export class LVGLChartWidget extends LVGLWidget {
                     // line, never exported into the generated source code
                     if (code.pageRuntime && code.pageRuntime.isEditor) {
                         code.callObjectFunction(
-                            "lv_chart_set_all_value",
+                            code.isLVGLVersion(["8.4.0", "9.2.2"])
+                                ? "lv_chart_set_all_value"
+                                : "lv_chart_set_all_values",
                             seriesObj,
                             series.previewValue
                         );

--- a/packages/project-editor/lvgl/widgets/Chart.tsx
+++ b/packages/project-editor/lvgl/widgets/Chart.tsx
@@ -1,30 +1,238 @@
 import React from "react";
-import { makeObservable } from "mobx";
+import { makeObservable, observable } from "mobx";
 
-import { makeDerivedClassInfo } from "project-editor/core/object";
+import { ColorFormat } from "project-editor/features/style/color-format";
 
-import { ProjectType } from "project-editor/project/project";
+import {
+    ClassInfo,
+    EezObject,
+    IMessage,
+    MessageType,
+    PropertyType,
+    getParent,
+    makeDerivedClassInfo
+} from "project-editor/core/object";
+
+import {
+    getName,
+    NamingConvention,
+    ProjectType
+} from "project-editor/project/project";
+
+import { specificGroup } from "project-editor/ui-components/PropertyGrid/groups";
 
 import { LVGLWidget } from "./internal";
+import { getChildOfObject, Message } from "project-editor/store";
+import { ProjectEditor } from "project-editor/project-editor-interface";
+import { LV_CHART_AXIS } from "project-editor/lvgl/lvgl-constants";
 import type { LVGLCode } from "project-editor/lvgl/to-lvgl-code";
 
 ////////////////////////////////////////////////////////////////////////////////
 
+export class LVGLChartSeries extends EezObject {
+    identifier: string;
+    color: string;
+    axis: keyof typeof LV_CHART_AXIS;
+    rangeMin: number;
+    rangeMax: number;
+
+    static classInfo: ClassInfo = {
+        properties: [
+            {
+                name: "identifier",
+                displayName: "Name",
+                type: PropertyType.String,
+                isOptional: true
+            },
+            {
+                name: "codeIdentifier",
+                type: PropertyType.String,
+                computed: true,
+                formText: `This identifier will be used in the generated source code. It is different from the "Name" above because in the source code we are following "lowercase with underscore" naming convention.`,
+                disabled: (object: LVGLChartSeries) =>
+                    object.codeIdentifier == undefined
+            },
+            {
+                name: "color",
+                type: PropertyType.ThemedColor
+            },
+            {
+                name: "axis",
+                displayName: "Y axis",
+                type: PropertyType.Enum,
+                enumItems: Object.keys(LV_CHART_AXIS).map(id => ({
+                    id,
+                    label: id
+                })),
+                enumDisallowUndefined: true
+            },
+            {
+                name: "rangeMin",
+                displayName: "Range min",
+                type: PropertyType.Number,
+                isOptional: true
+            },
+            {
+                name: "rangeMax",
+                displayName: "Range max",
+                type: PropertyType.Number,
+                isOptional: true
+            }
+        ],
+
+        listLabel: (series: LVGLChartSeries, collapsed: boolean) => {
+            const seriesIndex = (getParent(series) as LVGLChartSeries[]).indexOf(
+                series
+            );
+
+            if (collapsed) {
+                return (
+                    <>
+                        <span style={{ fontWeight: "bold", marginRight: 10 }}>
+                            #{seriesIndex}
+                        </span>
+                        <span>{series.identifier ?? ""}</span>
+                    </>
+                );
+            }
+
+            return <span style={{ fontWeight: "bold" }}>#{seriesIndex}</span>;
+        },
+
+        defaultValue: {
+            color: "#2196f3",
+            axis: "PRIMARY_Y"
+        },
+
+        check: (series: LVGLChartSeries, messages: IMessage[]) => {
+            const project = ProjectEditor.getProject(series);
+
+            if (!ColorFormat.isValid(series.color, project)) {
+                messages.push(
+                    new Message(
+                        MessageType.ERROR,
+                        `invalid color`,
+                        getChildOfObject(series, "color")
+                    )
+                );
+            }
+
+            if (
+                series.rangeMin != undefined &&
+                series.rangeMax != undefined &&
+                series.rangeMin > series.rangeMax
+            ) {
+                messages.push(
+                    new Message(
+                        MessageType.ERROR,
+                        `Range min must be less than or equal to Range max`,
+                        getChildOfObject(series, "rangeMin")
+                    )
+                );
+            }
+        }
+    };
+
+    override makeEditable() {
+        super.makeEditable();
+
+        makeObservable(this, {
+            identifier: observable,
+            color: observable,
+            axis: observable,
+            rangeMin: observable,
+            rangeMax: observable
+        });
+    }
+
+    get codeIdentifier() {
+        if (!this.identifier) {
+            return undefined;
+        }
+
+        const codeIdentifier = getName(
+            "",
+            this.identifier,
+            NamingConvention.UnderscoreLowerCase
+        );
+
+        if (codeIdentifier == this.identifier) {
+            return undefined;
+        }
+
+        return codeIdentifier;
+    }
+}
+
 export class LVGLChartWidget extends LVGLWidget {
+    series: LVGLChartSeries[];
+    pointCount: number;
+    divLineCountH: number;
+    divLineCountV: number;
+
     static classInfo = makeDerivedClassInfo(LVGLWidget.classInfo, {
         enabledInComponentPalette: (projectType: ProjectType) =>
             projectType === ProjectType.LVGL,
 
         componentPaletteGroupName: "!1Visualiser",
 
-        properties: [],
+        properties: [
+            {
+                name: "series",
+                type: PropertyType.Array,
+                typeClass: LVGLChartSeries,
+                propertyGridGroup: specificGroup,
+                partOfNavigation: false,
+                enumerable: false,
+                defaultValue: [],
+                showArrayCollapsedByDefaultInPropertyGrid: true,
+                hideElementIndexInPropertyGrid: true
+            },
+            {
+                name: "pointCount",
+                displayName: "Point count",
+                type: PropertyType.Number,
+                propertyGridGroup: specificGroup
+            },
+            {
+                name: "divLineCountH",
+                displayName: "Horizontal div lines",
+                type: PropertyType.Number,
+                propertyGridGroup: specificGroup
+            },
+            {
+                name: "divLineCountV",
+                displayName: "Vertical div lines",
+                type: PropertyType.Number,
+                propertyGridGroup: specificGroup
+            }
+        ],
 
         defaultValue: {
             left: 0,
             top: 0,
             width: 180,
             height: 100,
-            clickableFlag: true
+            clickableFlag: true,
+            pointCount: 10,
+            divLineCountH: 3,
+            divLineCountV: 5,
+            series: [Object.assign({}, LVGLChartSeries.classInfo.defaultValue)]
+        },
+
+        beforeLoadHook: (
+            object: LVGLChartWidget,
+            jsObject: Partial<LVGLChartWidget>
+        ) => {
+            if (jsObject.pointCount == undefined) {
+                jsObject.pointCount = 10;
+            }
+            if (jsObject.divLineCountH == undefined) {
+                jsObject.divLineCountH = 3;
+            }
+            if (jsObject.divLineCountV == undefined) {
+                jsObject.divLineCountV = 5;
+            }
         },
 
         icon: (
@@ -58,10 +266,87 @@ export class LVGLChartWidget extends LVGLWidget {
     override makeEditable() {
         super.makeEditable();
 
-        makeObservable(this, {});
+        makeObservable(this, {
+            series: observable,
+            pointCount: observable,
+            divLineCountH: observable,
+            divLineCountV: observable
+        });
     }
 
     override toLVGLCode(code: LVGLCode) {
         code.createObject("lv_chart_create");
+
+        code.callObjectFunction(
+            "lv_chart_set_point_count",
+            this.pointCount ?? 10
+        );
+
+        code.callObjectFunction(
+            "lv_chart_set_div_line_count",
+            this.divLineCountH ?? 3,
+            this.divLineCountV ?? 5
+        );
+
+        const setRangeFunctionName = code.isLVGLVersion(["8.4.0", "9.2.2"])
+            ? "lv_chart_set_range"
+            : "lv_chart_set_axis_range";
+
+        (this.series ?? []).forEach((series, i) => {
+            const seriesVar = code.genStateVar(
+                series.objID,
+                "lv_chart_series_t *",
+                series.identifier ? `${series.identifier}!` : "series"
+            );
+
+            code.buildColor(
+                series,
+                series.color,
+                () => seriesVar,
+                (color, seriesVar) => {
+                    const seriesObj = code.callObjectFunctionWithAssignment(
+                        "lv_chart_series_t *",
+                        `ser${i}`,
+                        "lv_chart_add_series",
+                        code.color(color),
+                        code.constant(`LV_CHART_AXIS_${series.axis}`)
+                    );
+
+                    code.assingToStateVar(seriesVar, seriesObj);
+
+                    if (
+                        series.rangeMin != undefined &&
+                        series.rangeMax != undefined
+                    ) {
+                        code.callObjectFunction(
+                            setRangeFunctionName,
+                            code.constant(`LV_CHART_AXIS_${series.axis}`),
+                            series.rangeMin,
+                            series.rangeMax
+                        );
+                    }
+                },
+                (color, seriesVar) => {
+                    if (code.lvglBuild) {
+                        const build = code.lvglBuild;
+                        if (code.screensLifetimeSupport) {
+                            build.line(
+                                `if (${seriesVar}) lv_chart_set_series_color(${code.objectAccessor}, ${seriesVar}, ${color});`
+                            );
+                        } else {
+                            build.line(
+                                `lv_chart_set_series_color(${code.objectAccessor}, ${seriesVar}, ${color});`
+                            );
+                        }
+                    } else {
+                        code.callObjectFunction(
+                            "lv_chart_set_series_color",
+                            seriesVar,
+                            code.color(color)
+                        );
+                    }
+                }
+            );
+        });
     }
 }

--- a/packages/project-editor/lvgl/widgets/Chart.tsx
+++ b/packages/project-editor/lvgl/widgets/Chart.tsx
@@ -35,6 +35,7 @@ export class LVGLChartSeries extends EezObject {
     axis: keyof typeof LV_CHART_AXIS;
     rangeMin: number;
     rangeMax: number;
+    previewValue: number;
 
     static classInfo: ClassInfo = {
         properties: [
@@ -77,6 +78,14 @@ export class LVGLChartSeries extends EezObject {
                 displayName: "Range max",
                 type: PropertyType.Number,
                 isOptional: true
+            },
+            {
+                name: "previewValue",
+                displayName: "Preview value",
+                type: PropertyType.Number,
+                isOptional: true,
+                formText:
+                    "Used only inside the editor: the series is drawn as a horizontal line at this value, so colors and ranges can be previewed. It is not exported into the generated source code."
             }
         ],
 
@@ -141,7 +150,8 @@ export class LVGLChartSeries extends EezObject {
             color: observable,
             axis: observable,
             rangeMin: observable,
-            rangeMax: observable
+            rangeMax: observable,
+            previewValue: observable
         });
     }
 
@@ -304,17 +314,29 @@ export class LVGLChartWidget extends LVGLWidget {
                 series.color,
                 () => seriesVar,
                 (color, seriesVar) => {
-                    const seriesObj = code.callObjectFunctionWithAssignment(
-                        "lv_chart_series_t *",
-                        `ser${i}`,
-                        "lv_chart_add_series",
-                        code.color(color),
-                        code.constant(`LV_CHART_AXIS_${series.axis}`)
-                    );
+                const seriesObj = code.callObjectFunctionWithAssignment(
+                    "lv_chart_series_t *",
+                    `ser${i}`,
+                    "lv_chart_add_series",
+                    code.color(color),
+                    code.constant(`LV_CHART_AXIS_${series.axis}`)
+                );
 
-                    code.assingToStateVar(seriesVar, seriesObj);
+                code.assingToStateVar(seriesVar, seriesObj);
 
-                    if (
+                if (series.previewValue != undefined) {
+                    // editor-only preview: draw the series as a horizontal
+                    // line, never exported into the generated source code
+                    if (code.pageRuntime && code.pageRuntime.isEditor) {
+                        code.callObjectFunction(
+                            "lv_chart_set_all_value",
+                            seriesObj,
+                            series.previewValue
+                        );
+                    }
+                }
+
+                if (
                         series.rangeMin != undefined &&
                         series.rangeMax != undefined
                     ) {


### PR DESCRIPTION
As discussed in #1050, this adds native design-time editing for the Chart widget. Until now the widget was created with a bare `lv_chart_create()` and had no editable properties.

## What is included

**Series** (`series` array of sub-objects, following the Meter indicators / ButtonMatrix buttons pattern), each with:
- `Name` — optional, used to name the generated series variable (like Meter scales)
- `Color` — themed color, resolved through `buildColor` (including live theme color updates via `lv_chart_set_series_color`)
- `Y axis` — `PRIMARY_Y` / `SECONDARY_Y`
- `Range min` / `Range max` — optional, emitted as `lv_chart_set_range()` (LVGL 8.4/9.2) / `lv_chart_set_axis_range()` (9.3+, renamed upstream)

**Chart level**: `Point count`, `Horizontal div lines`, `Vertical div lines`.

Runtime data feeding (set next value etc.) is intentionally left to flow/actions — the generated named state variables (`state-><name>`) give runtime code a handle for each series.

## Codegen before/after

Before:
```c
lv_obj_t *obj = lv_chart_create(parent_obj);
```

After (example with two series):
```c
lv_obj_t *obj = lv_chart_create(parent_obj);
lv_chart_set_point_count(obj, 12);
lv_chart_set_div_line_count(obj, 4, 8);
lv_chart_series_t *ser0 = lv_chart_add_series(obj, lv_color_hex(0xe51c23), LV_CHART_AXIS_PRIMARY_Y);
state->voltage = ser0;
lv_chart_set_range(obj, LV_CHART_AXIS_PRIMARY_Y, 0, 330);
lv_chart_series_t *ser1 = lv_chart_add_series(obj, lv_color_hex(0x009688), LV_CHART_AXIS_SECONDARY_Y);
state->current = ser1;
lv_chart_set_range(obj, LV_CHART_AXIS_SECONDARY_Y, -5, 5);
```

with the state struct in `screens.h`:
```c
typedef struct {
    lv_chart_series_t *voltage;
    lv_chart_series_t *current;
} screen_main_state_t;
```

## Not included (deliberately)

- **Chart type** (LINE/BAR/SCATTER): the `lv_chart_type_t` enum values drift across LVGL versions (9.4 inserts `STACKED`, 9.5 inserts `CURVE`), so a cross-version mapping would be needed — left for a follow-up if wanted.
- Update mode, axis ticks — can be added later on request.

## Testing

- check: 0 errors / 0 warnings on LVGL 8.4.0, 9.2.2 and 9.5.0 projects
- editor preview (wasm) renders the chart with div lines; property grid edits (add/remove series, colors, ranges) are reflected live
- generated C verified for all three versions (function name split verified)
- regression: existing project (Tabview/Roller/ButtonMatrix/labels, EEZ Flow) still builds with 0 errors and unchanged output