### PR TITLE
[LVGL] Add Table widget properties (row count, column widths, header texts)

### DIFF
--- a/packages/project-editor/lvgl/widgets/Table.tsx
+++ b/packages/project-editor/lvgl/widgets/Table.tsx
@@ -1,30 +1,145 @@
 import React from "react";
-import { makeObservable } from "mobx";
+import { makeObservable, observable } from "mobx";
 
-import { makeDerivedClassInfo } from "project-editor/core/object";
+import {
+    ClassInfo,
+    EezObject,
+    IMessage,
+    MessageType,
+    PropertyType,
+    getParent,
+    makeDerivedClassInfo
+} from "project-editor/core/object";
 
 import { ProjectType } from "project-editor/project/project";
 
+import { specificGroup } from "project-editor/ui-components/PropertyGrid/groups";
+
 import { LVGLWidget } from "./internal";
+import { Message } from "project-editor/store";
 import type { LVGLCode } from "project-editor/lvgl/to-lvgl-code";
 
 ////////////////////////////////////////////////////////////////////////////////
 
+export class LVGLTableColumn extends EezObject {
+    width: number;
+    headerText: string;
+
+    static classInfo: ClassInfo = {
+        properties: [
+            {
+                name: "width",
+                displayName: "Width",
+                type: PropertyType.Number,
+                formText: "Column width in pixels."
+            },
+            {
+                name: "headerText",
+                displayName: "Header text",
+                type: PropertyType.String,
+                isOptional: true,
+                formText:
+                    "If set, this text is written into row 0 of the table (commonly styled as a header row)."
+            }
+        ],
+
+        listLabel: (column: LVGLTableColumn, collapsed: boolean) => {
+            const columnIndex = (getParent(column) as LVGLTableColumn[]).indexOf(
+                column
+            );
+
+            if (collapsed) {
+                return (
+                    <>
+                        <span style={{ fontWeight: "bold", marginRight: 10 }}>
+                            #{columnIndex}
+                        </span>
+                        <span>{column.headerText ?? ""}</span>
+                    </>
+                );
+            }
+
+            return <span style={{ fontWeight: "bold" }}>#{columnIndex}</span>;
+        },
+
+        defaultValue: {
+            width: 80
+        },
+
+        check: (column: LVGLTableColumn, messages: IMessage[]) => {
+            if (column.width == undefined || column.width < 1) {
+                messages.push(
+                    new Message(
+                        MessageType.ERROR,
+                        `Column width must be at least 1`,
+                        column
+                    )
+                );
+            }
+        }
+    };
+
+    override makeEditable() {
+        super.makeEditable();
+
+        makeObservable(this, {
+            width: observable,
+            headerText: observable
+        });
+    }
+}
+
 export class LVGLTableWidget extends LVGLWidget {
+    rowCount: number;
+    columns: LVGLTableColumn[];
+
     static classInfo = makeDerivedClassInfo(LVGLWidget.classInfo, {
         enabledInComponentPalette: (projectType: ProjectType) =>
             projectType === ProjectType.LVGL,
 
         componentPaletteGroupName: "!1Basic",
 
-        properties: [],
+        properties: [
+            {
+                name: "rowCount",
+                displayName: "Row count",
+                type: PropertyType.Number,
+                propertyGridGroup: specificGroup
+            },
+            {
+                name: "columns",
+                displayName: "Columns",
+                type: PropertyType.Array,
+                typeClass: LVGLTableColumn,
+                propertyGridGroup: specificGroup,
+                partOfNavigation: false,
+                enumerable: false,
+                defaultValue: [],
+                showArrayCollapsedByDefaultInPropertyGrid: true,
+                hideElementIndexInPropertyGrid: true
+            }
+        ],
 
         defaultValue: {
             left: 0,
             top: 0,
             width: 180,
             height: 100,
-            clickableFlag: true
+            clickableFlag: true,
+            rowCount: 4,
+            columns: [
+                { width: 90, headerText: "Name" },
+                { width: 90, headerText: "Value" }
+            ]
+        },
+
+        beforeLoadHook: (
+            object: LVGLTableWidget,
+            jsObject: Partial<LVGLTableWidget>
+        ) => {
+            if (jsObject.rowCount == undefined) {
+                jsObject.rowCount = 4;
+            }
         },
 
         icon: (
@@ -46,10 +161,48 @@ export class LVGLTableWidget extends LVGLWidget {
     override makeEditable() {
         super.makeEditable();
 
-        makeObservable(this, {});
+        makeObservable(this, {
+            rowCount: observable,
+            columns: observable
+        });
     }
 
     override toLVGLCode(code: LVGLCode) {
         code.createObject("lv_table_create");
+
+        const columns = this.columns ?? [];
+        const rowCount = this.rowCount ?? 4;
+
+        // column count follows the number of column sub-objects
+        if (code.isV9) {
+            code.callObjectFunction("lv_table_set_column_count", columns.length);
+            code.callObjectFunction("lv_table_set_row_count", rowCount);
+        } else {
+            code.callObjectFunction("lv_table_set_col_cnt", columns.length);
+            code.callObjectFunction("lv_table_set_row_cnt", rowCount);
+        }
+
+        columns.forEach((column, i) => {
+            const width = column.width != undefined && column.width >= 1
+                ? column.width
+                : 1;
+
+            code.callObjectFunction(
+                code.isV9
+                    ? "lv_table_set_column_width"
+                    : "lv_table_set_col_width",
+                i,
+                width
+            );
+
+            if (column.headerText) {
+                code.callObjectFunction(
+                    "lv_table_set_cell_value",
+                    0,
+                    i,
+                    code.stringProperty("literal", column.headerText)
+                );
+            }
+        });
     }
 }


### PR DESCRIPTION
Companion to #1051 (as discussed in #1050): native design-time editing for the Table widget. Until now the widget was created with a bare `lv_table_create()` and had no editable properties.

## What is included

- `Row count`
- `Columns` — list of column sub-objects (same pattern as ButtonMatrix buttons / Meter indicators / #1051 chart series):
  - `Width` — column width in pixels
  - `Header text` — optional; if set, it is written into row 0 with `lv_table_set_cell_value()` (row 0 is commonly styled as a header row)
- the column count emitted to the generated code follows the number of column sub-objects

## Codegen before/after

Before:
```c
lv_obj_t *obj = lv_table_create(parent_obj);
```

After (3 columns with header texts, LVGL 9.x):
```c
lv_obj_t *obj = lv_table_create(parent_obj);
lv_table_set_column_count(obj, 3);
lv_table_set_row_count(obj, 4);
lv_table_set_column_width(obj, 0, 200);
lv_table_set_cell_value(obj, 0, 0, "Event");
lv_table_set_column_width(obj, 1, 120);
lv_table_set_cell_value(obj, 0, 1, "Time");
lv_table_set_column_width(obj, 2, 120);
lv_table_set_cell_value(obj, 0, 2, "Level");
```

For LVGL 8.4 the short function names are used: `lv_table_set_col_cnt`, `lv_table_set_row_cnt`, `lv_table_set_col_width`.

Filling cell contents at runtime stays with flow/actions — `lv_table_set_cell_value()` can be called on any cell from user code.

## Testing

- check: 0 errors / 0 warnings on LVGL 8.4.0, 9.2.2 and 9.5.0 projects
- editor preview (wasm) renders the table with correct column widths and header texts (verified pixel-exact against the configured column boundaries)
- generated C verified for all three versions (function name split verified)
- regression: existing project still builds with 0 errors and unchanged output